### PR TITLE
Running test require more than 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ jobs:
         - npm install -g grunt-cli
         - npm install --prefix build
         - grunt --level=WHITESPACE_ONLY --base build --gruntfile build/Gruntfile.js
-        - docker run -v $PWD/word:/opt/onlyoffice/documentbuilder/sdkjs/word
-                     -v $PWD/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell
-                     -v $PWD/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide
-                     onlyofficetestingrobot/doc-builder-testing:develop-latest
+        - docker pull onlyofficetestingrobot/doc-builder-testing:develop-latest
+        - travis_wait docker run -v $PWD/word:/opt/onlyoffice/documentbuilder/sdkjs/word
+                                 -v $PWD/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell
+                                 -v $PWD/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide
+                                 onlyofficetestingrobot/doc-builder-testing:develop-latest
 notifications:
   email:
     recipients:


### PR DESCRIPTION
I added some more test yesterday, so running time
require ~11 minutes on 1-core enviroment.
Seems travis don't like it and failing them.
`travis_wait` may fix the problem

Also extract `docker pull` to separate step, so time to docker pull didn't count in 20-minute timeout.