### PR TITLE
Increase timeout for running doc-builder-testing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ jobs:
         - npm install --prefix build
         - grunt --level=WHITESPACE_ONLY --base build --gruntfile build/Gruntfile.js
         - docker pull onlyofficetestingrobot/doc-builder-testing:develop-latest
-        - travis_wait docker run -v $PWD/word:/opt/onlyoffice/documentbuilder/sdkjs/word
-                                 -v $PWD/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell
-                                 -v $PWD/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide
-                                 onlyofficetestingrobot/doc-builder-testing:develop-latest
+        - travis_wait 30 docker run -v $PWD/word:/opt/onlyoffice/documentbuilder/sdkjs/word
+                                    -v $PWD/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell
+                                    -v $PWD/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide
+                                    onlyofficetestingrobot/doc-builder-testing:develop-latest
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Default timeout is 20 minutes, sometime it is not enough.