### PR TITLE
Allow failure for SonarQube Scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
                                     -v $PWD/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell
                                     -v $PWD/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide
                                     onlyofficetestingrobot/doc-builder-testing:develop-latest
+  allow_failures:
+    - stage: SonarQube Scanner                                    
 notifications:
   email:
     recipients:


### PR DESCRIPTION
For some reason SonarQube download link
is protected with user-password
I found no information about it and support
requiest is quiet, so need to allow failure
until more information.