### PR TITLE
Fix bug #41833

### DIFF
--- a/word/Editor/Run.js
+++ b/word/Editor/Run.js
@@ -7354,6 +7354,9 @@ ParaRun.prototype.SetPr = function(oTextPr)
 };
 ParaRun.prototype.Apply_TextPr = function(TextPr, IncFontSize, ApplyToAll)
 {
+	if (undefined === IncFontSize && this.Pr.Is_Equal(TextPr) && (!this.IsParaEndRun() || !this.Paragraph || this.Paragraph.TextPr.Value.Is_Equal(TextPr)))
+		return [null, this, null];
+
     var bReview = false;
     if (this.Paragraph && this.Paragraph.LogicDocument && this.Paragraph.bFromDocument && true === this.Paragraph.LogicDocument.IsTrackRevisions())
         bReview = true;


### PR DESCRIPTION
From now on, we don't add the changes to reviews with changes of the text properties if in fact there have been no changes