### PR TITLE
Comments in content control

### DIFF
--- a/word/Editor/Paragraph.js
+++ b/word/Editor/Paragraph.js
@@ -12040,6 +12040,8 @@ Paragraph.prototype.AddComment = function(Comment, bStart, bEnd)
 					if (null !== NewElement) {
 						this.Internal_Content_Add(EndPos + 1, NewElement);
 					}
+					this.Internal_Content_Add(EndPos + 1, CommentEnd);
+					this.Selection.EndPos = EndPos + 1;
 				} else if (68 === this.Content[EndPos].Type) {
 					this.Content[EndPos].AddComment(Comment, false, true);
 				} else {

--- a/word/Editor/Paragraph.js
+++ b/word/Editor/Paragraph.js
@@ -12035,16 +12035,17 @@ Paragraph.prototype.AddComment = function(Comment, bStart, bEnd)
 				var EndPos = EndContentPos.Get(0);
 
 				// Любые другие элементы мы целиком включаем в комментарий
-				if (para_Run === this.Content[EndPos].Type)
-				{
+				if (para_Run === this.Content[EndPos].Type) {
 					var NewElement = this.Content[EndPos].Split(EndContentPos, 1);
-
-					if (null !== NewElement)
+					if (null !== NewElement) {
 						this.Internal_Content_Add(EndPos + 1, NewElement);
+					}
+				} else if (68 === this.Content[EndPos].Type) {
+					this.Content[EndPos].AddComment(Comment, false, true);
+				} else {
+					this.Internal_Content_Add(EndPos + 1, CommentEnd);
+					this.Selection.EndPos = EndPos + 1;
 				}
-
-				this.Internal_Content_Add(EndPos + 1, CommentEnd);
-				this.Selection.EndPos = EndPos + 1;
 			}
 
 			if (true === bStart)
@@ -12063,14 +12064,15 @@ Paragraph.prototype.AddComment = function(Comment, bStart, bEnd)
 						this.Internal_Content_Add(StartPos + 1, NewElement);
 						NewElement.SelectAll();
 					}
-
 					this.Internal_Content_Add(StartPos + 1, CommentStart);
 					this.Selection.StartPos = StartPos + 1;
+				} else if(68===this.Content[EndPos].Type){
+					this.Content[EndPos].AddComment(Comment, true,false);
 				}
 				else
 				{
 					this.Internal_Content_Add(StartPos, CommentStart);
-					this.Selection.StartPos = StartPos;
+					this.Selection.StartPos = StartPos+1;
 				}
 			}
 		}

--- a/word/Editor/Paragraph.js
+++ b/word/Editor/Paragraph.js
@@ -12066,11 +12066,9 @@ Paragraph.prototype.AddComment = function(Comment, bStart, bEnd)
 					}
 					this.Internal_Content_Add(StartPos + 1, CommentStart);
 					this.Selection.StartPos = StartPos + 1;
-				} else if(68===this.Content[EndPos].Type){
-					this.Content[EndPos].AddComment(Comment, true,false);
-				}
-				else
-				{
+				} else if(68 === this.Content[StartPos].Type){
+					this.Content[StartPos].AddComment(Comment, true,false);
+				} else {
 					this.Internal_Content_Add(StartPos, CommentStart);
 					this.Selection.StartPos = StartPos+1;
 				}

--- a/word/Editor/StructuredDocumentTags/InlineLevel.js
+++ b/word/Editor/StructuredDocumentTags/InlineLevel.js
@@ -896,6 +896,48 @@ CInlineLevelSdt.prototype.ClearContentControl = function()
 	this.Add_ToContent(0, new ParaRun(this.GetParagraph(), false));
 	this.Remove_FromContent(1, this.Content.length - 1);
 };
+CInlineLevelSdt.prototype.AddComment = function(Comment, bStart, bEnd){ 
+	if(true === this.Selection.Use){
+		var StartContentPos = new CParagraphContentPos();
+		var EndContentPos = new CParagraphContentPos();
+		this.Get_ParaContentPos(true, true, StartContentPos, false);
+		this.Get_ParaContentPos(true, false, EndContentPos, false);
+
+		if(true===bEnd){
+			var CommentEnd = new ParaComment(false, Comment.Get_Id());
+			var EndPos = EndContentPos.Get(0);
+			if(para_Run == this.Content[EndPos].Type){
+				var NewElement = this.Content[EndPos].Split(EndContentPos, 1);
+				if (null !== NewElement){
+					this.Add_ToContent(EndPos+1,NewElement, true);
+				}
+				this.Add_ToContent(EndPos + 1, CommentEnd);
+				this.Selection.EndPos = EndPos + 1;
+			}else {
+				this.Add_ToContent(EndPos+1, CommentEnd);
+			}
+		}
+
+		if(true===bStart){
+			var CommentStart = new ParaComment(true, Comment.Get_Id());
+			var StartPos = StartContentPos.Get(0);
+			if (para_Run === this.Content[StartPos].Type) {
+				var NewElement = this.Content[StartPos].Split(StartContentPos, 1);
+
+				if (null !== NewElement) {
+					this.Add_ToContent(StartPos + 1, NewElement);
+					NewElement.SelectAll();
+				}
+				this.Add_ToContent(StartPos + 1, CommentStart);
+				this.Selection.StartPos = StartPos + 1;
+			} else {
+				this.Add_ToContent(StartPos, CommentStart);
+				this.Selection.StartPos = StartPos;
+			}
+		}
+	}
+
+};
 CInlineLevelSdt.prototype.CanAddComment = function()
 {
 	if (!this.CanBeDeleted() || (!this.CanBeEdited() && (!this.IsSelectedAll() || this.IsSelectedOnlyThis())))


### PR DESCRIPTION
# Description
When adding comments to text inside content controls, the entire content controls gets highlighted. 

# Step to recreate
1. Select some text inside a content control.
2. Add Comment.
3. The entire text of the control is highlighted.

# Expected behavior
Only the selected text should be highlighted.

This fixes the bug by handling content controls and then performing the same logic of splitting runs inside the control.