### PR TITLE
Modifications to get DocumentServer@sdkjs compiling under FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: $(WEBAPPS)
 
 $(WEBAPPS): $(WEBAPPS_FILES)
 	mkdir -p $(OUTPUT)/$(WEBAPPS_DIR) && \
-		cp -r -t $(OUTPUT)/$(WEBAPPS_DIR) ../$(WEBAPPS_DIR)/deploy/** 
+		cp -r ../$(WEBAPPS_DIR)/deploy/** $(OUTPUT)/$(WEBAPPS_DIR)
 
 $(WEBAPPS_FILES): $(NODE_MODULES) $(SDKJS_FILES)
 	cd ../$(WEBAPPS_DIR)/build  && \


### PR DESCRIPTION
Update the Makefile of DocumentServer@sdkjs in order to get it working under FreeBSD.
Since this Makefile is no more used it changes nothing..