### PR TITLE
[se] Fix bug 46308

### DIFF
--- a/cell/api.js
+++ b/cell/api.js
@@ -3190,8 +3190,7 @@ var editor;
           if (cellsChange.length !== 0 && lastFindOptions && !isCellEditing) {
             this.asc_replaceMisspelledWords(lastFindOptions);
           }
-        }
-        if (this.spellcheckState.isStart) {
+
           this.handlers.trigger("asc_onSpellCheckVariantsFound", null);
           this.spellcheckState.clean();
         }

--- a/cell/utils/utils.js
+++ b/cell/utils/utils.js
@@ -2777,12 +2777,6 @@
 			this.isIgnoreNumbers = false;
 		}
 
-		CSpellcheckState.prototype.init = function (startCell) {
-			if (!this.startCell) {
-				this.startCell = startCell.clone();
-				this.currentCell = startCell.clone();
-			}
-		};
 		CSpellcheckState.prototype.clean = function () {
 			this.isStart = false;
 			this.lastSpellInfo = null;


### PR DESCRIPTION
Use spellcheckState.startCell for detect spellcheck instead of isStart.
Delete unused init in CSpellcheckState