### PR TITLE
Add the type of editors "CSE" for metods

### DIFF
--- a/word/apiBuilder.js
+++ b/word/apiBuilder.js
@@ -2842,7 +2842,7 @@
 	/**
 	 * Create a radial gradient fill which allows to fill the object using a selected radial gradient as the object background.
 	 * @memberof Api
-	 * @typeofeditors ["CDE", "CPE"]
+	 * @typeofeditors ["CDE", "CSE", "CPE"]
 	 * @param {Array} aGradientStop - The array of gradient color stops measured in 1000th of percent.
 	 * @returns {ApiFill}
 	 */
@@ -5516,7 +5516,7 @@
 	/**
 	 * Get the type of this class.
 	 * @memberof ApiRun
-	 * @typeofeditors ["CDE", "CPE"]
+	 * @typeofeditors ["CDE", "CSE", "CPE"]
 	 * @returns {"run"}
 	 */
 	ApiRun.prototype.GetClassType = function()
@@ -10741,7 +10741,7 @@
 	/**
 	 * Get the type of this class.
 	 * @memberof ApiPresetColor
-	 * @typeofeditors ["CDE", "CPE"]
+	 * @typeofeditors ["CDE", "CSE", "CPE"]
 	 * @returns {"presetColor"}
 	 */
 	ApiPresetColor.prototype.GetClassType = function ()


### PR DESCRIPTION
Adding CSE Methods to Auto Build Jsdoc:

[cell.Api.createradialgradientfill](https://help.onlyoffice.com/products/files/doceditor.aspx?fileid=5004634&doc=SDVGaGVDQmU5OTNVVGw1TmNjVHpNVSs0bmltamdNc3pMWjRvbzhtRU1uST0_IjUwMDQ2MzQi0&action=embedded)
[cell.ApiPresetColor.getclasstype](https://help.onlyoffice.com/products/files/doceditor.aspx?fileid=5004573&doc=cFZUZDVFY2t6OSszd0U3SGpiT01tc2oyY0xxQWgyaXNJUXR0a0xsYWtiRT0_IjUwMDQ1NzMi0&action=embedded)
[cell.ApiRun.getclasstype](https://help.onlyoffice.com/products/files/doceditor.aspx?fileid=5006292&doc=SEF3VDUrYUdOWkJURlZLZ3p1NTFWVHBDajdRZStQWUZpVXZVamYwNkdJdz0_IjUwMDYyOTIi0&action=embedded)

