### PR TITLE
For bug #49727

### DIFF
--- a/word/api.js
+++ b/word/api.js
@@ -9549,7 +9549,7 @@ background-repeat: no-repeat;\
 		if (!oRun)
 			return null;
 
-		return oRun.GetTextFormAutoWidth();
+		return AscCommon.MMToTwips(oRun.GetTextFormAutoWidth());
 	};
 	asc_docs_api.prototype.asc_GetFormsCountByKey = function(sKey)
 	{


### PR DESCRIPTION
Now function GetTextFormAutoWidth returns twips instead of mm