### PR TITLE
fix: 🐛 groupshape oldobject type error

### DIFF
--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -9564,6 +9564,9 @@ function CPres()
                         if (shape.textBoxContent.Content.length == 0)
                             shape.textBoxContent.Internal_Content_Add(0, _old_cont);
 
+                        // Ole-object multiple graph traversal causes ParaDrawing not to be destroyed and next time it is set to Parent resulting in an error in the computation
+                        this.ParaDrawing = null
+
                         break;
                     }
                     case 5:


### PR DESCRIPTION
I try to resolve it. 
https://github.com/ONLYOFFICE/DocumentServer/issues/1308

The reason for the analysis is that multiple images are set ParaDrawing on CShape Parent in the calculation, which leads to the cumulative X and Y values of ParaDrawing in the calculation, leading to errors in Transform rendering

