### PR TITLE
fix: EastAsian script after a word can break the line

### DIFF
--- a/word/Editor/Run.js
+++ b/word/Editor/Run.js
@@ -3425,9 +3425,17 @@ ParaRun.prototype.Recalculate_Range = function(PRS, ParaPr, Depth)
                             {
 								if (!PRS.TryCondenseSpaces(SpaceLen + WordLen + LetterLen, WordLen + LetterLen, X, XEnd))
 								{
-									// Слово не убирается в отрезке. Переносим слово в следующий отрезок
-									MoveToLBP = true;
-									NewRange  = true;
+                                    if (AscCommon.isEastAsianScript(Item.Value) && Item.CanBeAtBeginOfLine()) 
+                                    {
+                                        NewRange = true;
+                                        RangeEndPos = Pos;
+                                    } 
+                                    else 
+                                    {
+                                        // Слово не убирается в отрезке. Переносим слово в следующий отрезок
+                                        MoveToLBP = true;
+                                        NewRange  = true;
+                                    }
 								}
                             }
                         }
@@ -3450,6 +3458,10 @@ ParaRun.prototype.Recalculate_Range = function(PRS, ParaPr, Depth)
                                 SpaceLen = 0;
                                 WordLen = 0;
                             }
+                        }
+                        if (AscCommon.isEastAsianScript(Item.Value) && Item.CanBeAtBeginOfLine()) 
+                        {
+                            PRS.Set_LineBreakPos(Pos, FirstItemOnLine);
                         }
                     }
 


### PR DESCRIPTION
content in word like this:
![image](https://user-images.githubusercontent.com/6120964/125456346-36956bbd-8da3-40ee-b663-c38760ac5f25.png)

but onlyoffice is like this:

The reason is that eastAsian script which can be at begin didnot break the line, so the English word 'cabloba' fall down into next line. That's not correct in MS word.
