### PR TITLE
fix: 🐛 first time new document touch device input Chinese

### DIFF
--- a/common/GlobalLoaders.js
+++ b/common/GlobalLoaders.js
@@ -224,6 +224,7 @@
                 this.AddLoadFonts("Wingdings", 0x0F);
                 this.AddLoadFonts("Courier New", 0x0F);
                 this.AddLoadFonts("Times New Roman", 0x0F);
+                this.AddLoadFonts("Open Sans", 0x0F);
             }
 
             this.Api.asyncFontsDocumentStartLoaded();


### PR DESCRIPTION
Because the Chinese input method will have pre-pinyin input, the input will generate a space, but that space belongs to open Sans asynchronous loading in the asynchronous font, although the Textarea does read-only operation, but the pinyin input method can not intercept, there will be strange behavior, input a few letters will be blocked. the following is the video of the problem

https://user-images.githubusercontent.com/6262739/134308038-9545fcda-eb1c-4d01-b9cf-b65e09f7f766.mp4

Consider this font is not large on the start of the default load, if there is a better opinion can also, thank you
