### PR TITLE
fix: disable mousewheel in modern browsers

### DIFF
--- a/common/apiBase.js
+++ b/common/apiBase.js
@@ -284,14 +284,33 @@
 		};
 
 		// disable mousewheel on macOS
-		if (AscCommon.AscBrowser.isMacOs)
-		{
-			document.body.onmousewheel = function(e) {
-				if (e.stopPropagation)
-					e.stopPropagation();
-				e.returnValue = false;
-				return false;
-			};
+		if (AscCommon.AscBrowser.isMacOs) {
+			let passiveIfSupported = false;
+			try {
+				document.body.addEventListener('test', null, Object.defineProperty({}, "passive", {
+					get: function () {
+						passiveIfSupported = {
+							passive = false
+						}
+					}
+				}));
+			} catch (err) { }
+			if (document.body.addEventListener) {
+				document.body.addEventListener('mousewheel', function (e) {
+					if (e.stopPropagation)
+						e.stopPropagation();
+					if (passiveIfSupported) {
+						e.preventDefault()
+					}
+				}, passiveIfSupported);
+			} else {
+				document.body.onmousewheel =  function (e) {
+					if (e.stopPropagation)
+						e.stopPropagation();
+					e.returnValue = false;
+					return false;
+				};
+			}
 		}
 	};
 	baseEditorsApi.prototype._editorNameById                 = function()


### PR DESCRIPTION
Original logic can't work well in modern browsers

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners