### PR TITLE
Fix incorrect docker image name used in unit-tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,4 +45,4 @@ jobs:
                       -v $PWD/deploy/sdkjs/word:/opt/onlyoffice/documentbuilder/sdkjs/word \
                       -v $PWD/deploy/sdkjs/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell \
                       -v $PWD/deploy/sdkjs/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide \
-                      onlyofficeqa/doc-builder-testing:latest
+                      onlyofficeqa/doc-builder-testing:latest rake rspec_critical

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,9 +40,9 @@ jobs:
            npm install -g grunt-cli
            npm install --prefix build
            grunt --level=WHITESPACE_ONLY --base build --gruntfile build/Gruntfile.js
-           docker pull onlyofficeqa/doc-builder-testing:develop-latest
+           docker pull onlyofficeqa/doc-builder-testing:latest
            docker run -v $PWD/deploy/sdkjs/common:/opt/onlyoffice/documentbuilder/sdkjs/common \
                       -v $PWD/deploy/sdkjs/word:/opt/onlyoffice/documentbuilder/sdkjs/word \
                       -v $PWD/deploy/sdkjs/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell \
                       -v $PWD/deploy/sdkjs/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide \
-                      onlyofficeqa/doc-builder-testing:develop-latest
+                      onlyofficeqa/doc-builder-testing:latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,9 +40,9 @@ jobs:
            npm install -g grunt-cli
            npm install --prefix build
            grunt --level=WHITESPACE_ONLY --base build --gruntfile build/Gruntfile.js
-           docker pull onlyofficetestingrobot/doc-builder-testing:develop-latest
+           docker pull onlyofficeqa/doc-builder-testing:develop-latest
            docker run -v $PWD/deploy/sdkjs/common:/opt/onlyoffice/documentbuilder/sdkjs/common \
                       -v $PWD/deploy/sdkjs/word:/opt/onlyoffice/documentbuilder/sdkjs/word \
                       -v $PWD/deploy/sdkjs/cell:/opt/onlyoffice/documentbuilder/sdkjs/cell \
                       -v $PWD/deploy/sdkjs/slide:/opt/onlyoffice/documentbuilder/sdkjs/slide \
-                      onlyofficetestingrobot/doc-builder-testing:develop-latest
+                      onlyofficeqa/doc-builder-testing:develop-latest


### PR DESCRIPTION
It was changes almost a year ago in:
https://github.com/ONLYOFFICE/doc-builder-testing/pull/541
But seems I forgot to change it here (

Also no point in using `develop` version, since the stable version, well... it's stable?