### PR TITLE
[bug] Fixed incompatibility of bAnchor parameters in Get_NearestPos method of different objects

### DIFF
--- a/word/Editor/Document.js
+++ b/word/Editor/Document.js
@@ -11653,7 +11653,7 @@ CDocument.prototype.Get_NearestPos = function(PageNum, X, Y, bAnchor, Drawing)
 	var ContentPos = this.Internal_GetContentPosByXY(X, Y, PageNum);
 
 	// Делаем логику как в ворде
-	if (true === bAnchor && ContentPos > 0 && PageNum > 0 && ContentPos === this.Pages[PageNum].Pos && ContentPos === this.Pages[PageNum - 1].EndPos && this.Pages[PageNum].EndPos > this.Pages[PageNum].Pos && type_Paragraph === this.Content[ContentPos].GetType() && true === this.Content[ContentPos].IsContentOnFirstPage())
+	if (true !== bAnchor && ContentPos > 0 && PageNum > 0 && ContentPos === this.Pages[PageNum].Pos && ContentPos === this.Pages[PageNum - 1].EndPos && this.Pages[PageNum].EndPos > this.Pages[PageNum].Pos && type_Paragraph === this.Content[ContentPos].GetType() && true === this.Content[ContentPos].IsContentOnFirstPage())
 		ContentPos++;
 
 	var ElementPageIndex = this.private_GetElementPageIndexByXY(ContentPos, X, Y, PageNum);


### PR DESCRIPTION
Repair the CDocument. Prototype. Get_NearestPos and CDocumentContent. Prototype. Get_NearestPos incompatibilities bAnchor parameters method

If you call this method in a CDocument object on a page-out and you get a coordinate element from the CBlockLevelSdt method you're going to get a different result between an element that gets the exact position and an element that doesn't get the exact position.

I used the machine translation to send this pull.

You can see the specific CDocumentContent. Prototype. Get_NearestPos and CDocument. Prototype. Get_NearestPos bAnchor of these two methods

You can look at what line of code is ContentPos++
