### PR TITLE
[feature]Recognize the percentage measure when pasting a table from a…

### DIFF
--- a/common/wordcopypaste.js
+++ b/common/wordcopypaste.js
@@ -8465,6 +8465,8 @@ PasteProcessor.prototype =
 		var oDocument = this.oDocument;
 		var tableNode = node, newNode, headNode;
 		var bPresentation = !PasteElementsId.g_bIsDocumentCopyPaste;
+		var bPercentWidth = node.style.width.indexOf('%') !== -1 || node.width.indexOf('%') !== -1;
+       	 	var nPercentWidth = bPercentWidth ? parseInt(node.style.width || node.width) : 0;
 
 		//Ищем если есть tbody
 		var i, length, j, length2;
@@ -8678,7 +8680,10 @@ PasteProcessor.prototype =
 			//набиваем content
 			this._ExecuteTable(tableNode, node, table, aSumGrid, nMaxColCount !== nMinColCount ? aColsCountByRow : null, pPr, bUseScaleKoef, dScaleKoef, arrShapes, arrImages, arrTables);
 			table.MoveCursorToStartPos();
-
+			
+	            	if (bPercentWidth) {
+	                	table.SetTableProps({TableWidth:-nPercentWidth});
+	            	}
 			if (!bPresentation) {
 				this.aContent.push(table);
 			}


### PR DESCRIPTION
Recognize the percentage measure when pasting a table from an external word.
When copying the percentage table into onlyoffice in an external word document, the correct unit is not recognized and the style of the external table is not displayed correctly in onlyoffice.       as follows:

Microsoft word
<img width="1957" alt="image" src="https://github.com/ONLYOFFICE/sdkjs/assets/42832987/6f3af897-fbe4-40c6-a631-7c88d4cc01fb">

OnlyOffice word
<img width="1394" alt="image" src="https://github.com/ONLYOFFICE/sdkjs/assets/42832987/97e7a0be-add5-4d40-8cf2-e10764340563">

