### PR TITLE
Fix bug #66963

### DIFF
--- a/word/apiBuilder.js
+++ b/word/apiBuilder.js
@@ -7546,7 +7546,6 @@
 	{
 		var oParagraph = this.Paragraph.Copy(undefined, private_GetDrawingDocument(), {
 			SkipComments          : true,
-			SkipAnchors           : true,
 			SkipFootnoteReference : true,
 			SkipComplexFields     : true
 		});


### PR DESCRIPTION
Stop preventing duplicating anchored images when copying a paragraph using builder script