### PR TITLE
Fix bug #61007

### DIFF
--- a/word/Math/LaTeXParser.js
+++ b/word/Math/LaTeXParser.js
@@ -1086,7 +1086,7 @@
 			arrMatrixContent.push(oContent);
 		}
 
-		while(arrMatrixContent.length < nCounter + 1)
+		while(arrMatrixContent.length < 1)
 		{
 			arrMatrixContent.push([]);
 		}
@@ -1125,6 +1125,19 @@
 		}
 
 		this.isNowMatrix = false;
+
+		if (strMatrixType.length > 0)
+		{
+			return {
+				type: oLiteralNames.bracketBlockLiteral[num],
+				value: {
+					type: oLiteralNames.matrixLiteral[num],
+					value: arrMatrixContent,
+				},
+				left: strMatrixType.length === 1 ? strMatrixType : strMatrixType[0],
+				right: strMatrixType.length === 1 ? strMatrixType : strMatrixType[1],
+			}
+		}
 
 		return {
 			type: oLiteralNames.matrixLiteral[num],

--- a/word/Math/operators.js
+++ b/word/Math/operators.js
@@ -4067,6 +4067,22 @@ CDelimiter.prototype.GetTextOfElement = function(isLaTeX) {
 
 	for (let intCount = 0; intCount < this.Content.length; intCount++)
 	{
+		// Word поддерживает только "matrix" (матрица без скобок) и "pmatrix"
+		// Пока делаем так же
+		if (isLaTeX && this.Content[intCount] instanceof CMathContent && this.Pr.begChr === 40 && this.Pr.endChr === 41)
+		{
+			if (this.Content[0].Content.length === 1 && this.Content[0].Content[0] instanceof CMathMatrix
+				||
+				this.Content[0].Content.length >= 2
+				&& this.Content[0].Content[0].Is_Empty()
+				&& this.Content[0].Content[2].Is_Empty()
+				&& this.Content[0].Content[1] instanceof CMathMatrix)
+			{
+				return this.Content[intCount].GetMultipleContentForGetText(isLaTeX, true);
+			}
+		}
+		//
+
 		strTemp += this.Content[intCount].GetMultipleContentForGetText(isLaTeX, true);
 		if (strSeparatorSymbol && this.Content.length > 1 && intCount < this.Content.length - 1)
 			strTemp += strSeparatorSymbol;


### PR DESCRIPTION
- Fix get linear math for LaTeX matrix with "\begin{}\end{}" constructions