### PR TITLE
Update apiBuilder.js

### DIFF
--- a/word/apiBuilder.js
+++ b/word/apiBuilder.js
@@ -6629,8 +6629,8 @@
 			"theme":     bWriteTheme ? oWriter.SerTheme(this.Document.GetTheme()) : undefined,
 			"sectPr":    bWriteSectionPr ? oWriter.SerSectionPr(this.Document.SectPr) : undefined,
 			"content":   oWriter.SerContent(this.Document.Content, undefined, undefined, undefined, true),
-			"numbering": bWriteNumberings ? oWriter.jsonWordNumberings : undefined,
-			"styles":    bWriteStyles ? oWriter.SerWordStylesForWrite() : undefined
+			"styles":    bWriteStyles ? oWriter.SerWordStylesForWrite() : undefined,
+			"numbering": bWriteNumberings ? oWriter.jsonWordNumberings : undefined			
 		}
 
 		return JSON.stringify(oResult);


### PR DESCRIPTION
bug fix: if a numbering was reference by a style only, the numbering will not export by ToJSON