### PR TITLE
feat(ApiRun): add GetInlineDrawings method to expose inline drawing positions

### DIFF
--- a/tests/word/plugins/pluginsApi.js
+++ b/tests/word/plugins/pluginsApi.js
@@ -295,6 +295,170 @@ $(function () {
 		
 		
 	})
-	
-	
+
+	QUnit.test("Test ApiRun.GetInlineDrawings", function (assert)
+	{
+		// --- Test 1: Run with text only, no drawings ---
+		AscTest.ClearDocument();
+		let p = MoveToNewParagraph();
+		AscTest.EnterText("Hello World");
+
+		let apiPara = Api.CreateParagraph();
+		logicDocument.AddToContent(logicDocument.GetElementsCount(), apiPara.Paragraph);
+		apiPara.Paragraph.SetThisElementCurrent();
+
+		// Get the run that contains "Hello World" from the first paragraph
+		let p1 = logicDocument.GetElement(logicDocument.GetElementsCount() - 2);
+		let apiPara1 = new AscWord.ApiParagraph(p1);
+		let run1 = apiPara1.GetElement(0);
+
+		assert.strictEqual(run1.GetClassType(), "run", "Element is a run");
+		let result1 = run1.GetInlineDrawings();
+		assert.ok(Array.isArray(result1), "GetInlineDrawings returns an array");
+		assert.strictEqual(result1.length, 0, "Text-only run returns empty array");
+
+		// --- Test 2: Run with a drawing only (no text) ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun2 = new ParaRun(p, false);
+		p.AddToContentToEnd(internalRun2);
+
+		let drawing2 = AscTest.CreateImage(50, 50);
+		internalRun2.Add_ToContent(0, drawing2);
+		drawing2.Set_Parent(internalRun2);
+
+		let apiPara2 = new AscWord.ApiParagraph(p);
+		let apiRun2 = apiPara2.GetElement(0);
+		let result2 = apiRun2.GetInlineDrawings();
+
+		assert.strictEqual(result2.length, 1, "Drawing-only run has 1 inline drawing");
+		assert.strictEqual(result2[0]["position"], 0, "Drawing-only run: position is 0");
+		assert.ok(result2[0]["drawing"], "Drawing-only run: drawing object exists");
+
+		// --- Test 3: Drawing between text ("AB[img]CD") ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun3 = new ParaRun(p, false);
+		internalRun3.AddText("ABCD");
+		p.AddToContentToEnd(internalRun3);
+
+		let drawing3 = AscTest.CreateImage(50, 50);
+		internalRun3.Add_ToContent(2, drawing3); // After A, B
+		drawing3.Set_Parent(internalRun3);
+
+		let apiPara3 = new AscWord.ApiParagraph(p);
+		let apiRun3 = apiPara3.GetElement(0);
+		let result3 = apiRun3.GetInlineDrawings();
+		let text3 = apiRun3.GetText();
+
+		assert.strictEqual(result3.length, 1, "Drawing between text: 1 inline drawing");
+		assert.strictEqual(result3[0]["position"], 2, "Drawing between text: position is 2 (after AB)");
+		assert.strictEqual(text3, "ABCD", "GetText returns text without drawing");
+
+		// Verify text splitting works correctly
+		let before3 = text3.substring(0, result3[0]["position"]);
+		let after3 = text3.substring(result3[0]["position"]);
+		assert.strictEqual(before3, "AB", "Text before drawing is 'AB'");
+		assert.strictEqual(after3, "CD", "Text after drawing is 'CD'");
+
+		// --- Test 4: Drawing at start ("[img]ABCD") ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun4 = new ParaRun(p, false);
+		internalRun4.AddText("ABCD");
+		p.AddToContentToEnd(internalRun4);
+
+		let drawing4 = AscTest.CreateImage(50, 50);
+		internalRun4.Add_ToContent(0, drawing4); // At start
+		drawing4.Set_Parent(internalRun4);
+
+		let apiPara4 = new AscWord.ApiParagraph(p);
+		let apiRun4 = apiPara4.GetElement(0);
+		let result4 = apiRun4.GetInlineDrawings();
+
+		assert.strictEqual(result4.length, 1, "Drawing at start: 1 inline drawing");
+		assert.strictEqual(result4[0]["position"], 0, "Drawing at start: position is 0");
+
+		// --- Test 5: Drawing at end ("ABCD[img]") ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun5 = new ParaRun(p, false);
+		internalRun5.AddText("ABCD");
+		p.AddToContentToEnd(internalRun5);
+
+		let drawing5 = AscTest.CreateImage(50, 50);
+		internalRun5.Add_ToContent(internalRun5.Content.length, drawing5); // At end
+		drawing5.Set_Parent(internalRun5);
+
+		let apiPara5 = new AscWord.ApiParagraph(p);
+		let apiRun5 = apiPara5.GetElement(0);
+		let result5 = apiRun5.GetInlineDrawings();
+
+		assert.strictEqual(result5.length, 1, "Drawing at end: 1 inline drawing");
+		assert.strictEqual(result5[0]["position"], 4, "Drawing at end: position equals text length (4)");
+
+		// --- Test 6: Multiple drawings ("A[img1]B[img2]C") ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun6 = new ParaRun(p, false);
+		internalRun6.AddText("ABC");
+		p.AddToContentToEnd(internalRun6);
+
+		// Insert second drawing first (at higher index) to avoid shifting
+		let drawing6b = AscTest.CreateImage(50, 50);
+		internalRun6.Add_ToContent(2, drawing6b); // After B: "AB[img2]C"
+		drawing6b.Set_Parent(internalRun6);
+
+		let drawing6a = AscTest.CreateImage(50, 50);
+		internalRun6.Add_ToContent(1, drawing6a); // After A: "A[img1]B[img2]C"
+		drawing6a.Set_Parent(internalRun6);
+
+		let apiPara6 = new AscWord.ApiParagraph(p);
+		let apiRun6 = apiPara6.GetElement(0);
+		let result6 = apiRun6.GetInlineDrawings();
+
+		assert.strictEqual(result6.length, 2, "Multiple drawings: 2 inline drawings");
+		assert.strictEqual(result6[0]["position"], 1, "Multiple drawings: first at position 1");
+		assert.strictEqual(result6[1]["position"], 2, "Multiple drawings: second at position 2");
+
+		// --- Test 7: Verify position matches GetText() index ---
+		AscTest.ClearDocument();
+		p = MoveToNewParagraph();
+
+		let internalRun7 = new ParaRun(p, false);
+		internalRun7.AddText("Hi ");
+		p.AddToContentToEnd(internalRun7);
+
+		let drawing7 = AscTest.CreateImage(50, 50);
+		internalRun7.Add_ToContent(internalRun7.Content.length, drawing7);
+		drawing7.Set_Parent(internalRun7);
+
+		// Add more text after drawing in the same run
+		let textAfter = new AscWord.CRunText(0x0057); // 'W'
+		internalRun7.Add_ToContent(internalRun7.Content.length, textAfter);
+		let textAfter2 = new AscWord.CRunText(0x006F); // 'o'
+		internalRun7.Add_ToContent(internalRun7.Content.length, textAfter2);
+
+		let apiPara7 = new AscWord.ApiParagraph(p);
+		let apiRun7 = apiPara7.GetElement(0);
+		let text7 = apiRun7.GetText();
+		let result7 = apiRun7.GetInlineDrawings();
+
+		assert.strictEqual(text7, "Hi Wo", "GetText returns 'Hi Wo' (3 + 2 chars)");
+		assert.strictEqual(result7.length, 1, "One drawing found");
+		assert.strictEqual(result7[0]["position"], 3, "Drawing at position 3 (after 'Hi ')");
+
+		// Verify splitting produces correct segments
+		let before7 = text7.substring(0, result7[0]["position"]);
+		let after7 = text7.substring(result7[0]["position"]);
+		assert.strictEqual(before7, "Hi ", "Text before drawing is 'Hi '");
+		assert.strictEqual(after7, "Wo", "Text after drawing is 'Wo'");
+	});
+
+
 });

--- a/word/apiBuilder.js
+++ b/word/apiBuilder.js
@@ -12880,14 +12880,101 @@
 	ApiRun.prototype.GetText = function(options)
 	{
 		options = options || {};
-		
+
 		return this.Run.GetText({
 			Text             : "",
 			NewLineSeparator : GetStringParameter(options["NewLineSeparator"], "\r"),
 			TabSymbol        : GetStringParameter(options["TabSymbol"], "\t")
 		});
 	};
-	
+
+	/**
+	 * Returns the inline drawings contained in this run with their character
+	 * positions within the run text.
+	 *
+	 * Each entry contains the {@link ApiDrawing} object and the zero-based
+	 * character index at which it appears in the string returned by
+	 * {@link ApiRun#GetText}. This allows callers to reconstruct the full
+	 * mixed content (text interleaved with drawings) in document order.
+	 *
+	 * Returns an empty array if the run contains no inline drawings.
+	 *
+	 * @memberof ApiRun
+	 * @typeofeditors ["CDE"]
+	 * @returns {Array<{drawing: ApiDrawing, position: number}>}
+	 *
+	 * @example
+	 * // Serialize a paragraph with inline images to markdown.
+	 * // Use GetAllDrawingObjects() on the paragraph first to skip
+	 * // paragraphs without drawings entirely (fast path).
+	 * var paraDrawings = paragraph.GetAllDrawingObjects();
+	 * if (paraDrawings.length === 0) {
+	 *   // No drawings — plain text only
+	 *   for (var i = 0; i < paragraph.GetElementsCount(); i++) {
+	 *     markdown += paragraph.GetElement(i).GetText();
+	 *   }
+	 * } else {
+	 *   // Has drawings — inspect each run for inline drawing positions
+	 *   for (var i = 0; i < paragraph.GetElementsCount(); i++) {
+	 *     var el = paragraph.GetElement(i);
+	 *     if (el.GetClassType() === "run") {
+	 *       var text = el.GetText();
+	 *       var inlineDrawings = el.GetInlineDrawings();
+	 *       if (inlineDrawings.length === 0) {
+	 *         markdown += text;
+	 *       } else {
+	 *         // Split text at drawing positions and interleave placeholders
+	 *         var lastPos = 0;
+	 *         for (var j = 0; j < inlineDrawings.length; j++) {
+	 *           var pos = inlineDrawings[j].position;
+	 *           markdown += text.substring(lastPos, pos);
+	 *           markdown += "{{IMG:" + inlineDrawings[j].drawing.GetName() + "}}";
+	 *           lastPos = pos;
+	 *         }
+	 *         markdown += text.substring(lastPos);
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 *
+	 * @see office-js-api/Examples/{Editor}/ApiRun/Methods/GetInlineDrawings.js
+	 */
+	ApiRun.prototype.GetInlineDrawings = function()
+	{
+		var arrResult   = [];
+		var arrContent  = this.Run.Content;
+		var nCharIndex  = 0;
+
+		for (var nPos = 0, nCount = arrContent.length; nPos < nCount; ++nPos)
+		{
+			var oItem = arrContent[nPos];
+
+			switch (oItem.Type)
+			{
+				case para_Drawing:
+				{
+					arrResult.push({
+						"drawing"  : GetApiDrawing(oItem.GraphicObj) || new ApiDrawing(oItem.GraphicObj),
+						"position" : nCharIndex
+					});
+					break;
+				}
+				case para_Text:
+				case para_Space:
+				case para_Tab:
+				case para_NewLine:
+				case para_Math_Text:
+				case para_Math_BreakOperator:
+				{
+					nCharIndex++;
+					break;
+				}
+			}
+		}
+
+		return arrResult;
+	};
+
 	/**
 	 * Moves a cursor to a specified position of the current text run.
 	 * If the current run is not assigned to any document part, then <b>false</b> is returned. Otherwise, this method returns <b>true</b>.
@@ -29799,6 +29886,7 @@
 	ApiRun.prototype["ToJSON"]                       = ApiRun.prototype.ToJSON;
 	ApiRun.prototype["AddComment"]                   = ApiRun.prototype.AddComment;
 	ApiRun.prototype["GetText"]                      = ApiRun.prototype.GetText;
+	ApiRun.prototype["GetInlineDrawings"]            = ApiRun.prototype.GetInlineDrawings;
 	ApiRun.prototype["MoveCursorToPos"]              = ApiRun.prototype.MoveCursorToPos;
 
 


### PR DESCRIPTION
## Summary

Adds `ApiRun.prototype.GetInlineDrawings()` — returns inline drawings contained in a run with their character positions within the run text.

## Problem

`ApiParagraph` provides two disconnected ways to access content:

| Method | Returns | Includes drawings? | Position info? |
|--------|---------|---------------------|----------------|
| `GetElementsCount()` + `GetElement(i)` | Runs and hyperlinks in order | **No** | Yes (index) |
| `GetAllDrawingObjects()` | All drawings in the paragraph | Yes | **No** |

There is no way to determine where an inline drawing sits relative to text within its parent run. Inline drawings are children of `ParaRun.Content[]`, but this structure is not exposed through the public API.

Approaches we tried that don't work: `GetElement(i)` checking for drawings (never returned), `drawing.GetParentRun()` (doesn't exist), `drawing.GetRange()`/`drawing.GetPosition()` (don't exist), empty-run heuristic (unreliable — anchor run merges with adjacent whitespace).

## Motivation

We are building an AI writing assistant plugin ([Cozy Cloud](https://cozy.io/)) that needs to:
1. Extract selected text as markdown with image placeholders at correct positions
2. Send to LLM (which preserves placeholders)
3. Reinject text with images restored at their new positions

Step 1 requires knowing the character position of each inline drawing within its run.

## Changes

- **`word/apiBuilder.js`**: Add `ApiRun.prototype.GetInlineDrawings` implementation (~30 lines) + string-key export for Closure Compiler
- **`tests/word/plugins/pluginsApi.js`**: QUnit tests covering all edge cases

## API

```javascript
/**
 * @memberof ApiRun
 * @typeofeditors ["CDE"]
 * @returns {Array<{drawing: ApiDrawing, position: number}>}
 */
ApiRun.prototype.GetInlineDrawings = function() { ... }
```

### Return value

Each entry contains:
- `drawing`: `ApiDrawing` (or subclass: `ApiImage`, `ApiShape`, etc.) via `GetApiDrawing()` factory
- `position`: Zero-based character index matching `GetText()` output

Character counting matches `ParaRun.prototype.Get_Text()`: counts `para_Text`, `para_Space`, `para_Tab`, `para_NewLine`, `para_Math_Text`, `para_Math_BreakOperator`. Drawings (`para_Drawing`) produce no character in `GetText()` — they are invisible in the text string.

### Example usage

```javascript
var paraDrawings = paragraph.GetAllDrawingObjects();
if (paraDrawings.length > 0) {
  for (var i = 0; i < paragraph.GetElementsCount(); i++) {
    var el = paragraph.GetElement(i);
    if (el.GetClassType() === "run") {
      var text = el.GetText();
      var inlineDrawings = el.GetInlineDrawings();
      if (inlineDrawings.length > 0) {
        var lastPos = 0;
        for (var j = 0; j < inlineDrawings.length; j++) {
          var pos = inlineDrawings[j].position;
          result += text.substring(lastPos, pos);
          result += "{{IMG:" + inlineDrawings[j].drawing.GetName() + "}}";
          lastPos = pos;
        }
        result += text.substring(lastPos);
      } else {
        result += text;
      }
    }
  }
}
```

## Test coverage

QUnit tests covering:
- Run with text only (no drawings) → empty array
- Run with drawing only (no text) → position 0
- Drawing between text ("AB[img]CD") → position 2
- Drawing at start → position 0
- Drawing at end → position equals text length
- Multiple drawings → positions increase monotonically
- Position-to-GetText consistency (text splitting produces correct segments)

## Impact

- **Purely additive**: No changes to existing methods or return types
- **No breaking changes**: New method only, existing behavior unchanged
- **Performance**: Negligible — iterates run content (typically <20 elements), only called when needed
- **Backwards compatible**: Callers first check `paragraph.GetAllDrawingObjects().length > 0` (existing method) to skip paragraphs without drawings entirely