### PR TITLE
Add ApiDocument.GetCurrentComments() to builder API

### DIFF
--- a/word/apiBuilder.js
+++ b/word/apiBuilder.js
@@ -8719,6 +8719,31 @@
 	};
 
 	/**
+	 * Returns the comments for the current cursor position or selection.
+	 * If the cursor is placed within one or more comment ranges, those comments are returned.
+	 * If no comments are found at the current position, an empty array is returned.
+	 * @memberof ApiDocument
+	 * @typeofeditors ["CDE"]
+	 * @returns {ApiComment[]}
+	 */
+	ApiDocument.prototype.GetCurrentComments = function()
+	{
+		let arrIds = this.Document.GetAllComments(false, true);
+		if (!arrIds || arrIds.length === 0)
+			return [];
+
+		let oCommManager = this.Document.GetCommentsManager();
+		let aResult = [];
+		for (let i = 0; i < arrIds.length; i++)
+		{
+			let oComment = oCommManager.GetById(arrIds[i]);
+			if (oComment)
+				aResult.push(new ApiComment(oComment));
+		}
+		return aResult;
+	};
+
+	/**
 	 * Returns a comment from the current document by its ID.
 	 * @memberof ApiDocument
 	 * @typeofeditors ["CDE"]
@@ -29626,6 +29651,7 @@
 	ApiDocument.prototype["AddEndnote"]                    = ApiDocument.prototype.AddEndnote;
 	ApiDocument.prototype["SetControlsHighlight"]          = ApiDocument.prototype.SetControlsHighlight;
 	ApiDocument.prototype["GetAllComments"]                = ApiDocument.prototype.GetAllComments;
+	ApiDocument.prototype["GetCurrentComments"]            = ApiDocument.prototype.GetCurrentComments;
 	ApiDocument.prototype["GetCommentById"]                = ApiDocument.prototype.GetCommentById;
 	ApiDocument.prototype["ShowComment"]                   = ApiDocument.prototype.ShowComment;
 	ApiDocument.prototype["GetStatistics"]                 = ApiDocument.prototype.GetStatistics;


### PR DESCRIPTION
## What

Adds `ApiDocument.GetCurrentComments()` — returns comments at the current cursor position or selection as `ApiComment[]`.

## Why

I'm building an ONLYOFFICE plugin that uses comments for metadata annotations (rules, variants). When the user right-clicks, the plugin needs to know if the cursor is inside an existing comment to show "Edit" vs "Add" in the context menu.

Currently `GetAllComments()` returns every comment in the document with no way to filter by cursor position. The only workarounds involve calling minified internal methods (fragile) or matching `GetQuoteText()` with `Search()` (fails on long text and whitespace normalization differences between the two).

## Implementation

Purely additive — wraps the existing `CDocument.GetAllComments(false, true)` which already supports positional filtering via its `isCurrent` parameter. This is the same code path the editor's own UI uses for comment highlighting. The new method just exposes it through the builder API, following the same pattern as the existing `GetAllComments()`.

```javascript
// Plugin usage inside callCommand:
var comments = Api.GetDocument().GetCurrentComments();
for (var i = 0; i < comments.length; i++) {
    var text = comments[i].GetText();
    var id = comments[i].GetId();
}
```