### PR TITLE
Guard default OForm placeholder text

### DIFF
--- a/word/Editor/GlossaryDocument.js
+++ b/word/Editor/GlossaryDocument.js
@@ -44,6 +44,11 @@ var c_oAscDefaultPlaceholderName = {
 	SignatureOform : "DefaultPlaceholder_SIGNATURE_OFORM",
 };
 
+function private_NormalizePlaceholderText(sText)
+{
+	return ("string" === typeof sText) ? sText : "";
+}
+
 /**
  * Класс для хранения и работы с дополнительными DocContents
  * @param {CDocument} oLogicDocument
@@ -249,6 +254,7 @@ CGlossaryDocument.prototype.private_CreateDefaultPlaceholder = function(sName, s
 	let logicDocument = this.LogicDocument;
 	let styles = logicDocument ? logicDocument.GetStyles() : null;
 	let defaultStyle = styles ? styles.GetDefaultPlaceholderText() : null;
+	sText = private_NormalizePlaceholderText(sText);
 	
 	var oDocPart = this.CreateDocPart(sName);
 
@@ -278,7 +284,7 @@ CGlossaryDocument.prototype.private_CreateDefaultOformPlaceholder = function(sNa
 	var oParagraph = oDocPart.GetFirstParagraph();
 	var oRun       = new ParaRun();
 	oParagraph.AddToContent(0, oRun);
-	sText = sText.replaceAll(' ', '\u00A0');
+	sText = private_NormalizePlaceholderText(sText).replaceAll(' ', '\u00A0');
 	oRun.AddText(sText);
 	
 	oDocPart.SetDocPartBehavior(c_oAscDocPartBehavior.Content);


### PR DESCRIPTION
## Summary
- normalize default placeholder text before building glossary placeholders
- avoid crashing the word editor when OForm placeholder text is undefined or non-string
- preserve existing behavior for valid translated placeholder strings

## Why
Opening a Word document through a Nextcloud integration on April 12, 2026 triggered a frontend crash in the editor with .

The runtime error came from the generated word bundle in the OForm placeholder path:



Tracing the generated stack back to source leads to , where  called  unconditionally. Even if the upstream source of the unexpected value is elsewhere, this path should not assume translated placeholder text is always a valid string during editor initialization.

## Notes
- this patch fixes the crash at the source level instead of patching generated assets
- I also normalized the non-OForm placeholder path for consistency
- I was not able to run the full upstream test suite locally in this environment
