### PR TITLE
fix(fonts): show the logical font name when a font is substituted

### DIFF
--- a/common/libfont/textshaper.js
+++ b/common/libfont/textshaper.js
@@ -116,7 +116,10 @@
 		this.ResetBuffer();
 		
 		let oFontInfo = this.GetFontInfo(this.FontSlot);
-		let nFontId   = AscCommon.FontNameMap.GetId(this.FontId.m_pFaceInfo.family_name);
+		// register the requested (logical) font name rather than the physical face name of
+		// the substitute, so the toolbar keeps showing the font used in the document
+		// (e.g. "Times New Roman") even when it is not installed and has been substituted
+		let nFontId   = AscCommon.FontNameMap.GetId(oFontInfo.Name);
 		AscCommon.g_oTextMeasurer.SetFontInternal(this.FontId.m_pFaceInfo.family_name, AscFonts.MEASURE_FONTSIZE, oFontInfo.Style);
 
 		this.FontSize = oFontInfo.Size;


### PR DESCRIPTION
## What Problem This Solves

On Linux, when the font used in a document is not installed (e.g. "Times New Roman"), the toolbar initially shows the font name from the document style, but after clicking elsewhere in the document it switches to the physical face name of the substitute (e.g. "Caladea"). See https://github.com/ONLYOFFICE/DesktopEditors/issues/2405.

## Why This Change Was Made

- **Root cause**: in `CTextShaper::FlushWord` the id registered in `FontNameMap` was built from `this.FontId.m_pFaceInfo.family_name` — the physical face name of the substituted font. The toolbar (`AscFonts.GetFontNameByFontId` -> `FontNameMap.GetName`) then displays the substitute's real name instead of the font name used in the document.
- **Architecture affected**: text shaping (`common/libfont/textshaper.js`) and grapheme rendering (`common/libfont/grapheme.js`, which resolves the font name back from the id).
- **Why this solution**: register the requested (logical) font name (`oFontInfo.Name`) instead. When no substitution occurs both names are equal, so behavior is unchanged; when a substitution occurs the toolbar now shows the document font name consistently. The renderer still substitutes the logical name at draw time via the same `GetByParams` logic, producing the same glyphs. A companion PR in core makes the same standard fonts available in the dropdown.

## User Impact

- The toolbar no longer unexpectedly switches to the substitute's physical name ("Caladea") when the cursor moves; it keeps showing the font used in the document ("Times New Roman").
- Rendering output is identical (same substitute faces are selected by the renderer).
- No behavior change on web or on systems where all document fonts are installed.

## Solution Details

- `common/libfont/textshaper.js` (`FlushWord`, one line): `AscCommon.FontNameMap.GetId(oFontInfo.Name)` instead of `GetId(this.FontId.m_pFaceInfo.family_name)`.
- `grapheme.js` needs no change: the grapheme stores the map id and `DrawGrapheme` calls `SetFontInternal` with the mapped name; the core renderer substitutes it with the same face chosen at shaping time.

## Evidence

- `node --check` on `common/libfont/textshaper.js`: syntax OK.
- Logic verified against the full chain: `FlushWord` (textshaper.js:116-131), `GetFontNameByFontId` (libfont/grapheme.js:265-268), `DrawGrapheme` (grapheme.js:78-82), `FontNameMap` (common/nameMap.js).
- Full build is not feasible in this environment; CI will compile the change.

## Closes #2405