### PR TITLE
Convert numbers to text with Excel's 15 significant digits in cNumber.tocString

### DIFF
--- a/cell/model/FormulaObjects/parserFormula.js
+++ b/cell/model/FormulaObjects/parserFormula.js
@@ -611,6 +611,23 @@ Math.fmod = function ( a, b ) {
 	return Number( (a - (this.floor( a / b ) * b)).toPrecision( cExcelSignificantDigits ) );
 };
 
+/**
+ * Converts a number to text the way Excel does, keeping at most cExcelSignificantDigits
+ * significant digits. The default JavaScript Number -> String conversion produces the
+ * shortest round-trip representation, which can reach 17 significant digits, so 8.5/24
+ * stringifies as "0.3541666666666667" where Excel produces "0.354166666666667".
+ * The difference is visible whenever a number is concatenated into text (=A1&B1) and
+ * breaks exact lookups whose key was built by Excel.
+ * @param {number} val
+ * @returns {string}
+ */
+function convertNumberToExcelString( val ) {
+	if ( !isFinite( val ) ) {
+		return "" + val;
+	}
+	return "" + parseFloat( val.toPrecision( cExcelSignificantDigits ) );
+}
+
 
 
 parserHelp.setDigitSeparator(AscCommon.g_oDefaultCultureInfo.NumberDecimalSeparator);
@@ -750,7 +767,7 @@ parserHelp.setDigitSeparator(AscCommon.g_oDefaultCultureInfo.NumberDecimalSepara
 	cNumber.prototype.constructor = cNumber;
 	cNumber.prototype.type = cElementType.number;
 	cNumber.prototype.tocString = function () {
-		return new cString(("" + this.value).replace(FormulaSeparators.digitSeparatorDef,
+		return new cString(convertNumberToExcelString(this.value).replace(FormulaSeparators.digitSeparatorDef,
 			FormulaSeparators.digitSeparator));
 	};
 	cNumber.prototype.tocNumber = function () {


### PR DESCRIPTION

## What

`cNumber.prototype.tocString` used the default JavaScript `Number -> String`
conversion, which produces the shortest round-trip representation and can reach
17 significant digits. Excel converts numbers to text with at most 15 significant
digits, so any formula that concatenates a number into text produced a different
string in ONLYOFFICE than in Excel.

The visible symptom is that an exact-match `VLOOKUP(..., FALSE)` on a key built
with `&` succeeds in Excel and fails in ONLYOFFICE, so the formula silently falls
through to its error branch and displays a wrong (but plausible) number.

Reported in ONLYOFFICE/DocumentServer#3761.

## How

This adds `convertNumberToExcelString()` next to `Math.fmod` and uses it in
`cNumber.prototype.tocString`. It reuses the `cExcelSignificantDigits` constant
that already exists in the same file, so the 15-digit rule is now applied on the
number-to-text path as well.

Non-finite values are passed through unchanged; `cNumber`'s constructor already
rejects `NaN`/`Infinity` into `cError`, so this is only a safety net.

Only the text form changes - the stored numeric value of a cell is untouched, so
arithmetic results are unaffected.

## Verification

Unit level, on the exact function body taken from the patched source:

- `8.5/24` -> `0.354166666666667` (was `0.3541666666666667`), so a key built with
  `&` now matches the one written by Excel
- values that already fit in 15 significant digits are byte-identical to before:
  `0`, `1`, `-1`, `0.5`, `0.1`, `2.5`, `100`, `-273.15`, `1e21`, `1e-7`, `5e-324`,
  `1e308`, `1234567890`, `0.000123456`, `25569`, `45000.5`
- now matches Excel where raw JS differed: `0.1+0.2` -> `0.3`,
  `1/3` -> `0.333333333333333`, `1.005*100` -> `100.5`
- 16-digit input follows Excel's own rounding: `9007199254740991` -> `9007199254740990`
- every produced string still parses back to the same 15-digit value

Built bundle, A/B on `sdk-all.js` produced by `build/build.py --product cell`,
loaded in a browser and calling `AscCommonExcel.cNumber(...).tocString()`:

| | before | after |
| --- | --- | --- |
| `8.5/24` | `0.3541666666666667` | `0.354166666666667` |
| key matches Excel | no | yes |
| `0.1+0.2` | `0.30000000000000004` | `0.3` |

End to end, same document opened in Document Server with and without the patch,
then saved through the editor and inspected:

| | generated key | `VLOOKUP` result |
| --- | --- | --- |
| stock | `KEY0.35416666666666671.0625` | `NO MATCH` |
| patched | `KEY0.3541666666666671.0625` | `15.5` |

A minimal reproducer workbook is attached to the issue.

## Possible follow-up (not in this PR)

`cNumber.prototype.toLocaleString` has the same `this.value.toString()` pattern.
It feeds display/API paths rather than formula results, so I left it alone to keep
this change small - happy to include it if you would prefer.
