### PR TITLE
Carry sub-row wheel remainder on macOS so precision devices can scroll the sheet

### DIFF
--- a/cell/view/EventsController.js
+++ b/cell/view/EventsController.js
@@ -74,6 +74,11 @@
 			this.hsbApi = undefined;
 			this.hsbMax = undefined;
 
+			// Sub-row wheel movement carried from one event to the next; see
+			// _onMouseWheel. Only used on the macOS smooth-scroll path.
+			this.macWheelRestX = 0;
+			this.macWheelRestY = 0;
+
 			this.resizeTimerId = undefined;
 			this.scrollTimerId = undefined;
 			this.moveRangeTimerId = undefined;
@@ -2135,6 +2140,21 @@
 			if (wb.smoothScroll && AscCommon.AscBrowser.isMacOs) {
 				deltaX = (values.x / wb.getWorksheet().getHScrollStep()) * AscCommon.AscBrowser.retinaPixelRatio;
 				deltaY = (values.y / wb.getWorksheet().getVScrollStep()) * AscCommon.AscBrowser.retinaPixelRatio;
+
+				// Dividing by the row height turns a per-pixel device into a fraction
+				// of a row per event: an Apple trackpad or Magic Mouse reports deltas
+				// small enough that the result never reaches one row, so the sheet
+				// stands still however hard the user flicks. Carry the remainder over
+				// so those events add up instead of being dropped one at a time.
+				// A change of direction starts from zero, so a reversal is immediate.
+				if (deltaX * this.macWheelRestX < 0) { this.macWheelRestX = 0; }
+				if (deltaY * this.macWheelRestY < 0) { this.macWheelRestY = 0; }
+				deltaX += this.macWheelRestX;
+				deltaY += this.macWheelRestY;
+				this.macWheelRestX = deltaX - Math.trunc(deltaX);
+				this.macWheelRestY = deltaY - Math.trunc(deltaY);
+				deltaX = Math.trunc(deltaX);
+				deltaY = Math.trunc(deltaY);
 			} else {
 				if (undefined !== event.wheelDelta && 0 !== event.wheelDelta) {
 					deltaY = -1 * event.wheelDelta / 40;


### PR DESCRIPTION
Fixes ONLYOFFICE/DocumentServer#3762.

On macOS the spreadsheet does not scroll with the wheel at all when the device
reports per-pixel deltas — Apple trackpad, Magic Mouse, free-spinning wheels. The
scrollbars work and Ctrl+wheel zooms, so the events do arrive; they simply never
amount to a whole row.

## Why

`_onMouseWheel` divides the delta by the row height on the macOS smooth-scroll
path, and the result is used as a row count:

```js
deltaY = (values.y / wb.getWorksheet().getVScrollStep()) * AscCommon.AscBrowser.retinaPixelRatio;
```

Measured on an affected machine — `getVScrollStep()` 37, `retinaPixelRatio` 2 —
that is `values.y × 0.054`. One row needs `values.y ≥ 18.5`, i.e. `|wheelDelta| ≥ 50`,
while the device peaks at 18 (`values.y = 6`, `deltaY = 0.32`). Every event yields
a fraction, and nothing carries it forward, so the sheet never moves.

`smoothWheelCorrector` exists to accumulate exactly this, but it is only consulted
on the other branch (`if (this.smoothWheelCorrector && !wb.smoothScroll)`), so the
macOS path has no accumulator at all.

## What this changes

The remainder is kept between events instead of being truncated away each time,
and reset when the direction changes so a reversal responds immediately.

Simulating twenty consecutive events captured from an affected device:

| | rows scrolled |
| --- | --- |
| before | 0 |
| after | 1 |

Notched wheels are untouched: 120 per notch still gives `values.y = 45` and two
rows, as today. The pace set by the fix for #244 is preserved — this only stops
sub-row movement from being discarded. Whether that pace suits precision devices
is the separate question the existing `//TODO for mac touchpads. need review`
already raises, and I have deliberately not touched the divisor, since lowering it
would re-open #244.

## Testing

I do not have a build environment for the full editor, so this has not been run
through a compiled Document Server. What I did check: the file parses, the changed
branch is the macOS smooth-scroll one only, the fields are initialised in the
constructor so the first event cannot produce `NaN`, and the arithmetic was
simulated against the real captured deltas (numbers in the table above). Happy to
test a build, or to adjust if you would rather route this through
`smoothWheelCorrector` for consistency with the other branch.
