### PR TITLE
Compare numbers the way Excel appears to, and route conditional formatting through it

### DIFF
--- a/cell/model/ConditionalFormatting.js
+++ b/cell/model/ConditionalFormatting.js
@@ -841,7 +841,9 @@
 					if (!cell || cell.isNullTextString()) {
 						res = 0 === v1.getValue();
 					} else if (cell.type === CellValueType.Number) {
-						res = cell.getNumberValue() === v1.getValue();
+						//Through compareNumbers so a rule agrees with the same comparison written
+						//as a formula: a total reached by two different routes is one value.
+						res = 0 === AscCommon.compareNumbers(cell.getNumberValue(), v1.getValue());
 					} else {
 						res = false;
 					}
@@ -870,7 +872,7 @@
 					if (!cell || cell.isNullTextString()) {
 						res = 0 > v1.getValue();
 					} else if (cell.type === CellValueType.Number) {
-						res = cell.getNumberValue() > v1.getValue();
+						res = AscCommon.compareNumbers(cell.getNumberValue(), v1.getValue()) > 0;
 					} else {
 						res = true;
 					}

--- a/common/NumFormat.js
+++ b/common/NumFormat.js
@@ -155,6 +155,22 @@ function getNumberParts(x)
 
 	function compareNumbers(val1, val2) {
 		var res = 0;
+		//Two numbers that differ by less than half a unit in the 15th significant digit
+		//compare as equal, which is the behaviour observed in Excel. Rounding each operand
+		//to that many digits on its own - what the mantissa comparison below does - is not
+		//the same test: a pair can straddle a rounding boundary and still come out one
+		//digit apart, which is what happens to a column total compared against the same
+		//total reached by multiplying.
+		//The threshold is taken from the operand of *smaller* magnitude. That matters only
+		//when the two sit on opposite sides of a power of ten, where the smaller one is the
+		//one carrying the finer last digit; taking the larger there would accept
+		//differences Excel rejects. Sign plays no part.
+		if (val1 !== val2 && isFinite(val1) && isFinite(val2)) {
+			var dMin = Math.min(Math.abs(val1), Math.abs(val2));
+			if (0 !== dMin && Math.abs(val1 - val2) < 0.5 * Math.pow(10, getNumberParts(dMin).exponent)) {
+				return 0;
+			}
+		}
 		var parts1 = getNumberParts(val1);
 		var parts2 = getNumberParts(val2);
 		if (parts1.sign === parts2.sign) {

--- a/common/test/comparenumbers.html
+++ b/common/test/comparenumbers.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>compareNumbers regression tests</title>
+		<script>window.AscCommon = {}; window.Asc = {}; window.AscFonts = {}; window.AscCommonExcel = {};</script>
+		<script src="./../NumFormat.js"></script>
+		<script src="./comparenumbers.js"></script>
+	</head>
+	<body onload="javascript: runCompareNumbersTests();">
+		Results are written to the browser console.
+	</body>
+</html>

--- a/common/test/comparenumbers.js
+++ b/common/test/comparenumbers.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/*
+ * Regression tests for AscCommon.compareNumbers.
+ *
+ * From this directory:  node comparenumbers.js   (exit code 1 if anything fails)
+ * Or open comparenumbers.html and read the browser console.
+ *
+ * The boundaries below were read off Microsoft Excel 16.111.3 on macOS by building
+ * base + k * ulp(base) and finding the largest k that still compares equal.
+ */
+(function () {
+	"use strict";
+
+	/* Decided up front: the node branch below defines window, so this cannot be
+	   re-tested later on. */
+	var isNode = (typeof window === "undefined");
+	var root;
+	if (!isNode) {
+		/* The html page has already set up the namespaces and loaded NumFormat.js. */
+		root = window;
+	} else {
+		/* Under node, give NumFormat.js the globals it writes into, then load it. */
+		root = global;
+		root.window = root;
+		root.AscCommon = root.AscCommon || {};
+		root.Asc = root.Asc || {};
+		root.AscFonts = root.AscFonts || {};
+		root.AscCommonExcel = root.AscCommonExcel || {};
+		require("../NumFormat.js");
+	}
+
+	var cmp = root.AscCommon.compareNumbers;
+	var failures = 0, total = 0;
+
+	function log(s) {
+		if (typeof console !== "undefined" && console.log) {
+			console.log(s);
+		}
+	}
+
+	function check(name, actual, expected) {
+		total++;
+		var ok = (actual === expected);
+		if (!ok) {
+			failures++;
+		}
+		log((ok ? "PASS  " : "FAIL  ") + name + "   got " + actual + ", expected " + expected);
+	}
+
+	function sign(n) {
+		return n < 0 ? -1 : (n > 0 ? 1 : 0);
+	}
+
+	function checkCmp(name, a, b, expected) {
+		check(name, sign(cmp(a, b)), expected);
+	}
+
+	/* Largest k for which base and base + direction * k * 2^ulpExp still compare equal. */
+	function largestEqualK(base, ulpExp, direction) {
+		var ulp = Math.pow(2, ulpExp);
+		for (var k = 1; k < 4096; k++) {
+			if (0 !== cmp(base, base + direction * k * ulp)) {
+				return k - 1;
+			}
+		}
+		return -1;
+	}
+
+	function checkBoundary(name, base, ulpExp, direction, expectedK) {
+		check(name, largestEqualK(base, ulpExp, direction), expectedK);
+	}
+
+	function run() {
+		/* The case this was written for: a column total against the same total reached
+		   by multiplying. The two are one bit apart and straddle the 15-digit rounding
+		   boundary, so rounding each operand separately does not make them equal. */
+		checkCmp("total by SUM vs by product", 6.4583333333333348, 6.4583333333333339, 0);
+
+		/* Ordinary comparisons must be unaffected. */
+		checkCmp("plainly smaller", 1, 2, -1);
+		checkCmp("plainly greater", 2, 1, 1);
+		checkCmp("identical", 1.5, 1.5, 0);
+		checkCmp("zero against zero", 0, 0, 0);
+		checkCmp("zero against tiny", 0, 1e-300, -1);
+		checkCmp("tiny against zero", 1e-300, 0, 1);
+		checkCmp("negative against positive", -1e-20, 1e-20, -1);
+
+		/* A difference in the last stored digit is a real difference. */
+		checkCmp("15th digit differs", 1.00000000000001, 1.00000000000002, -1);
+		checkCmp("15th digit differs, negated", -1.00000000000001, -1.00000000000002, 1);
+
+		/* Boundaries, against the values measured in Excel. */
+		checkBoundary("boundary at 1", 1, -52, 1, 22);
+		checkBoundary("boundary at 1024", 1024, -42, 1, 21);
+		checkBoundary("boundary at 0.03125", 0.03125, -57, 1, 7);
+		checkBoundary("boundary at 3.125", 3.125, -51, 1, 11);
+		checkBoundary("boundary at 1e200", 1e200, 612, 1, 29);
+
+		/* The threshold follows the decimal exponent, so it steps by ten across a power
+		   of ten even though the binary spacing is the same on both sides. */
+		checkBoundary("boundary just below ten", 9.9, -49, 1, 2);
+		checkBoundary("boundary just above ten", 10.1, -49, 1, 28);
+
+		/* When the two operands sit on opposite sides of a power of ten, the threshold
+		   comes from the smaller one. Sign plays no part in any of this. */
+		checkBoundary("crossing one downwards", 1, -53, -1, 4);
+		checkBoundary("crossing one downwards, negated", -1, -52, 1, 2);
+		checkBoundary("negative, no crossing", -1, -52, -1, 22);
+
+		log("");
+		log(failures ? (failures + " of " + total + " failed") : ("all " + total + " passed"));
+		return failures;
+	}
+
+	if (isNode) {
+		process.exitCode = run() ? 1 : 0;
+	} else {
+		root.runCompareNumbersTests = run;
+	}
+})();


### PR DESCRIPTION
Fixes ONLYOFFICE/DocumentServer#3769.

A total reached by adding a column and the same total reached by multiplying are not the
same double - `SUM(a1:a20)` and `20*a1` land one bit apart. Excel and LibreOffice compare
such a pair as equal; we do not, so a `cellIs greaterThan` rule fires against a value that
should have compared equal and the cell gets the wrong format.

## Changes

**`common/NumFormat.js` - `compareNumbers`**

The function already rounds both operands to `gc_nMaxDigCount` digits before comparing
mantissas, but rounding each operand on its own is not the same test as looking at the
difference: a pair can straddle a rounding boundary and still come out one digit apart.
`6.4583333333333348` rounds to `645833333333334` while `6.4583333333333339` rounds to
`645833333333333`.

Added a check on the difference first. The threshold is half a unit in the 15th
significant digit, taken from the operand of smaller magnitude; `getNumberParts` already
returns that exponent, so `Math.pow(10, exponent)` is the unit and half of it is the
threshold.

**`cell/model/ConditionalFormatting.js` - `_cellIsNumber`**

Conditional formatting compared numbers with the raw JavaScript operators and never went
through `compareNumbers`, so a rule disagreed with the same comparison written as a
formula. Routed the two numeric branches through it. `Operator_notEqual`,
`Operator_greaterThanOrEqual`, `Operator_lessThan`, `Operator_lessThanOrEqual`,
`Operator_between` and `Operator_notBetween` are all derived from `Operator_equal` and
`Operator_greaterThan`, so these two are the only call sites that need changing.

**`common/test/comparenumbers.js`, `common/test/comparenumbers.html`** - new

Twenty assertions, laid out like the existing `common/geometry/test` and
`common/libfont/test`. From `common/test`, `node comparenumbers.js` prints the results
and exits 1 if anything fails - it sets up the globals `NumFormat.js` writes into and
loads it itself, so nothing else is needed. The html page does the same in a browser and
writes to the console. Three of the twenty fail before this change and all pass after.

## Where the threshold comes from

It is measured rather than chosen. Building `base + k * ulp(base)` and finding the largest
`k` that still compares equal, on Excel 16.111.3 / macOS:

| base | direction | Excel 16.111.3 | LibreOffice 26.2.4.2 |
| --- | --- | --- | --- |
| `1` | up | 22 | 22 |
| `1024` | up | 21 | 21 |
| `0.03125` | up | 7 | 15 **differs** |
| `3.125` | up | 11 | 24 **differs** |
| `9.9` | up | 2 | 19 **differs** |
| `10.1` | up | 28 | 28 |
| `1E+200` | up | 29 | 29 |
| `1` | down | 4 | 31 **differs** |
| `-1` | up | 2 | 15 **differs** |
| `-1` | down | 22 | 22 |

All ten are reproduced by the rule above, and all ten are in the test file. Two details
the numbers force:

- The threshold follows the **decimal** exponent. `9.9` and `10.1` have the same binary
  spacing but their `k` differs by more than ten times, so a single relative epsilon does
  not reproduce this.
- It comes from the **smaller** magnitude, which only shows up when the operands sit on
  opposite sides of a power of ten - `1` perturbed downwards gives 4, `-1` perturbed
  downwards gives 22. Sign plays no part.

I would describe this as a rule that fits these observations on one build, not as a
documented specification. If you have a reference for what Excel actually does, I am happy
to adjust the threshold to match it - the shape of the patch would not change.

Worth knowing before taking the numbers as universal: **LibreOffice does not use the same
tolerance** - the third column above. The two agree wherever the leading digits are close
to 1 and LibreOffice is more lenient everywhere else, with no crossing behaviour, so it is
not tied to the decimal exponent. They agree on the reproducer but not on the rule, and
this patch deliberately follows Excel. If you would rather match something simpler, the
same two call sites are still the place for it.

## Deliberately not changed

Addition and subtraction have their own correction in Excel, on a binary threshold, and in
what I could observe it applies only to the last operation of a formula: `=1+7*2^-52-1`
gives `0`, but `=(1+7*2^-52-1)*2^52` gives `7`, and `SUM` corrects its own result even when
nested. Applying a correction to every subtraction would return `0` where Excel returns
`7`, so this patch leaves arithmetic results alone and changes only how numbers are
compared. `=a-b` still returns the exact difference.

## Testing

- `common/test/comparenumbers.js`: 3 of 20 fail before, 20 of 20 pass after.
- `tolerance_probe.xlsx` opened in the patched editor reports the same boundary as Excel
  on all ten rows.
- The reproducer attached to the issue: the cell stays blue and the two comparison
  formulas match Excel.
- `test-vlookup.xlsx` from #1383 returns the same result before and after this change.
- Checked against Excel 16.111.3 and LibreOffice Calc 26.2.4.2 on the same files; both
  keep the cell blue in the reproducer.

## Scope note

`compareNumbers` is shared with `cell/model/PivotTables.js`, where it decides grouping
boundaries. I have not exercised that path - the same "same number, different route"
argument seems to apply, but if you would rather keep the change out of pivot tables it
would need a separate entry point. Your call.

The conditional formatting change is covered only by the attached workbook; the derived
operators are reached through `Operator_equal` and `Operator_greaterThan` by construction,
but I have not written automated tests for that file since it does not load standalone.
