### PR TITLE
Keep the per-script fonts of a theme through the file round trip

### DIFF
--- a/common/Drawings/Format/Format.js
+++ b/common/Drawings/Format/Format.js
@@ -9975,11 +9975,24 @@
 		drawingConstructorsMap[AscDFH.historyitem_ExtraClrScheme_SetClrScheme] = ClrScheme;
 		drawingConstructorsMap[AscDFH.historyitem_NvPr_AddExt] = CExtP;
 
+		function SupplementalFont(script, typeface) {
+			this.script = script;
+			this.typeface = typeface;
+		}
+
+		SupplementalFont.prototype.createDuplicate = function () {
+			return new SupplementalFont(this.script, this.typeface);
+		};
+
 		function FontCollection(fontScheme) {
 			CBaseNoIdObject.call(this);
 			this.latin = null;
 			this.ea = null;
 			this.cs = null;
+			// <a:font script="..."/> entries: the per-script fonts of the collection.
+			// Never edited in the editors, but they must survive the file round trip:
+			// without them applications fall back to latin for East Asian text.
+			this.supplementalFont = [];
 			if (fontScheme) {
 				this.setFontScheme(fontScheme);
 			}
@@ -10006,6 +10019,19 @@
 			if (this.fontScheme)
 				this.fontScheme.checkFromFontCollection(pr, this, FONT_REGION_CS);
 		};
+		FontCollection.prototype.addSupplementalFont = function (script, typeface) {
+			this.supplementalFont.push(new SupplementalFont(script, typeface));
+		};
+		FontCollection.prototype.setSupplementalFont = function (arr) {
+			this.supplementalFont = [];
+			for (var i = 0; i < arr.length; ++i) {
+				this.supplementalFont.push(arr[i].createDuplicate());
+			}
+		};
+		/* supplementalFont is deliberately left out of Write_ToBinary / Read_FromBinary:
+		   that is the history format, a bare concatenation with no length framing, so
+		   adding a field here would desynchronise every reader that does not have it.
+		   The cost is that undoing a font scheme replacement does not restore them. */
 		FontCollection.prototype.Write_ToBinary = function (w) {
 			writeString(w, this.latin);
 			writeString(w, this.ea);
@@ -10065,6 +10091,9 @@
 			oCopy.minorFont.setLatin(this.minorFont.latin);
 			oCopy.minorFont.setEA(this.minorFont.ea);
 			oCopy.minorFont.setCS(this.minorFont.cs);
+
+			oCopy.majorFont.setSupplementalFont(this.majorFont.supplementalFont);
+			oCopy.minorFont.setSupplementalFont(this.minorFont.supplementalFont);
 			return oCopy;
 		};
 		FontScheme.prototype.Refresh_RecalcData = function () {
@@ -20593,6 +20622,7 @@
 		window['AscFormat'].ClrMap = ClrMap;
 		window['AscFormat'].ExtraClrScheme = ExtraClrScheme;
 		window['AscFormat'].FontCollection = FontCollection;
+		window['AscFormat'].SupplementalFont = SupplementalFont;
 		window['AscFormat'].FontScheme = FontScheme;
 		window['AscFormat'].FmtScheme = FmtScheme;
 		window['AscFormat'].ThemeElements = ThemeElements;

--- a/common/Drawings/Format/Format.js
+++ b/common/Drawings/Format/Format.js
@@ -10019,6 +10019,9 @@
 			if (this.fontScheme)
 				this.fontScheme.checkFromFontCollection(pr, this, FONT_REGION_CS);
 		};
+		FontCollection.prototype.clearSupplementalFont = function () {
+			this.supplementalFont.length = 0;
+		};
 		FontCollection.prototype.addSupplementalFont = function (script, typeface) {
 			this.supplementalFont.push(new SupplementalFont(script, typeface));
 		};

--- a/common/Drawings/Format/Format.js
+++ b/common/Drawings/Format/Format.js
@@ -10034,7 +10034,9 @@
 		/* supplementalFont is deliberately left out of Write_ToBinary / Read_FromBinary:
 		   that is the history format, a bare concatenation with no length framing, so
 		   adding a field here would desynchronise every reader that does not have it.
-		   The cost is that undoing a font scheme replacement does not restore them. */
+		   Undo and redo in this process keep the entries, because they restore the object
+		   itself; what is lost is a font scheme replacement that has gone through the
+		   serialised history - collaborative editing and replay. */
 		FontCollection.prototype.Write_ToBinary = function (w) {
 			writeString(w, this.latin);
 			writeString(w, this.ea);

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5276,8 +5276,18 @@ function BinaryPPTYLoader()
                 }
                 case 3:
                 {
-                    var _len = s.GetULong();
-                    s.Skip2(_len);
+                    var _start_supplemental = s.cur;
+                    var _end_supplemental = _start_supplemental + s.GetULong() + 4;
+                    var _count = s.GetULong();
+                    // The count comes out of the file, so it is also bounded by the end of
+                    // the record: a corrupt one must not send the reader off past it.
+                    for (var i = 0; i < _count && s.cur < _end_supplemental; ++i)
+                    {
+                        s.Skip2(1); // type
+                        var _font = this.ReadSupplementalFont();
+                        fontcolls.addSupplementalFont(_font.script, _font.typeface);
+                    }
+                    s.Seek2(_end_supplemental);
                     break;
                 }
                 default:
@@ -5289,6 +5299,57 @@ function BinaryPPTYLoader()
         }
 
         s.Seek2(_end_rec);
+    };
+
+    this.ReadSupplementalFont = function()
+    {
+        var s = this.stream;
+
+        var _rec_start = s.cur;
+        var _end_rec = _rec_start + s.GetULong() + 4;
+
+        var script = "";
+        var typeface = "";
+
+        s.Skip2(1); // start attributes
+
+        var _unknown = false;
+        while (!_unknown)
+        {
+            var _at = s.GetUChar();
+            if (_at == g_nodeAttributeEnd)
+                break;
+
+            switch (_at)
+            {
+                case 0:
+                {
+                    script = s.GetString2();
+                    break;
+                }
+                case 1:
+                {
+                    typeface = s.GetString2();
+                    break;
+                }
+                default:
+                {
+                    // An attribute this build does not know: there is no length in front
+                    // of it, so its value cannot be stepped over and everything read from
+                    // here on would be out of step. Stop, and let the seek below put the
+                    // stream back on the record boundary. Anything after the unknown
+                    // attribute is dropped, which is preferable to reading on until a byte
+                    // happens to look like the end marker - past the end of the stream
+                    // GetUChar keeps returning 0, so that search need never finish.
+                    _unknown = true;
+                    break;
+                }
+            }
+        }
+
+        s.Seek2(_end_rec);
+
+        return { script: script, typeface: typeface };
     };
 
     this.ReadTextFontTypeface = function()

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5312,6 +5312,24 @@ function BinaryPPTYLoader()
         s.Seek2(_end_rec);
     };
 
+    this.ReadStringInRecord = function(nEnd)
+    {
+        var s = this.stream;
+
+        // GetString2 holds the length it reads against the end of the data, not against
+        // the end of the record being read, so a corrupt one would pull in bytes that
+        // belong to whatever follows. Give up on the record instead: seeking to its end
+        // also ends the loop this is called from.
+        var nLen = s.GetULong();
+        if (nLen < 0 || s.cur + 2 * nLen > nEnd)
+        {
+            s.Seek2(nEnd);
+            return "";
+        }
+
+        return s.GetString(nLen);
+    };
+
     this.ReadSupplementalFont = function(nEndLimit)
     {
         var s = this.stream;
@@ -5339,12 +5357,12 @@ function BinaryPPTYLoader()
             {
                 case 0:
                 {
-                    script = s.GetString2();
+                    script = this.ReadStringInRecord(_end_rec);
                     break;
                 }
                 case 1:
                 {
-                    typeface = s.GetString2();
+                    typeface = this.ReadStringInRecord(_end_rec);
                     break;
                 }
                 default:

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5252,7 +5252,10 @@ function BinaryPPTYLoader()
         var s = this.stream;
 
         var _rec_start = s.cur;
-        var _end_rec = _rec_start + s.GetULong() + 4;
+        // The record length is read from the file, so it is held to the end of the data as
+        // well: past that GetUChar returns 0 without moving, and this loop would keep
+        // handing that to a reader that has no end of its own to stop at.
+        var _end_rec = Math.min(_rec_start + s.GetULong() + 4, s.size);
 
         while (s.cur < _end_rec)
         {
@@ -5279,15 +5282,17 @@ function BinaryPPTYLoader()
                     var _start_supplemental = s.cur;
                     var _end_supplemental = _start_supplemental + s.GetULong() + 4;
                     var _count = s.GetULong();
-                    // The count comes out of the file, so it is also bounded by the end of
-                    // the record: a corrupt one must not send the reader off past it.
+                    fontcolls.clearSupplementalFont();
+                    // Everything here comes out of the file, so nothing is trusted on its
+                    // own: the count is bounded by the end of the record as well, and each
+                    // entry is told where it has to stop.
                     for (var i = 0; i < _count && s.cur < _end_supplemental; ++i)
                     {
                         s.Skip2(1); // type
-                        var _font = this.ReadSupplementalFont();
+                        var _font = this.ReadSupplementalFont(_end_supplemental);
                         fontcolls.addSupplementalFont(_font.script, _font.typeface);
                     }
-                    s.Seek2(_end_supplemental);
+                    s.Seek2(Math.min(_end_supplemental, s.size));
                     break;
                 }
                 default:
@@ -5301,12 +5306,15 @@ function BinaryPPTYLoader()
         s.Seek2(_end_rec);
     };
 
-    this.ReadSupplementalFont = function()
+    this.ReadSupplementalFont = function(nEndLimit)
     {
         var s = this.stream;
 
         var _rec_start = s.cur;
-        var _end_rec = _rec_start + s.GetULong() + 4;
+        // The length is read from the file, so it is held to the end of the record this
+        // entry belongs to and to the end of the data: a corrupt one must not let an entry
+        // eat what follows it, or point beyond the stream.
+        var _end_rec = Math.min(_rec_start + s.GetULong() + 4, nEndLimit, s.size);
 
         var script = "";
         var typeface = "";
@@ -5314,8 +5322,9 @@ function BinaryPPTYLoader()
         s.Skip2(1); // start attributes
 
         var _unknown = false;
-        while (!_unknown)
+        while (!_unknown && s.cur < _end_rec)
         {
+            var _prev_pos = s.cur;
             var _at = s.GetUChar();
             if (_at == g_nodeAttributeEnd)
                 break;
@@ -5334,19 +5343,27 @@ function BinaryPPTYLoader()
                 }
                 default:
                 {
-                    // An attribute this build does not know: there is no length in front
-                    // of it, so its value cannot be stepped over and everything read from
-                    // here on would be out of step. Stop, and let the seek below put the
-                    // stream back on the record boundary. Anything after the unknown
-                    // attribute is dropped, which is preferable to reading on until a byte
-                    // happens to look like the end marker - past the end of the stream
-                    // GetUChar keeps returning 0, so that search need never finish.
+                    // An attribute this build does not know: there is no length in front of
+                    // it, so its value cannot be stepped over and everything read from here
+                    // on would be out of step. Stop, and let the seek below put the stream
+                    // back on the record boundary. Anything after the unknown attribute is
+                    // dropped, which is preferable to reading on out of step.
                     _unknown = true;
                     break;
                 }
             }
+
+            // Reading short of the end of the data leaves the position where it was -
+            // GetULong stops without moving when fewer than four bytes are left - so the
+            // record boundary on its own is not enough to get out of this loop.
+            if (s.cur <= _prev_pos)
+                break;
         }
 
+        // Between the boundary and the check above, an attribute block that was never
+        // terminated cannot run past this entry. Past the end of the data GetUChar returns
+        // 0, which is a valid attribute id, so a search for the end marker would otherwise
+        // never finish.
         s.Seek2(_end_rec);
 
         return { script: script, typeface: typeface };

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5288,11 +5288,17 @@ function BinaryPPTYLoader()
                     // Everything here comes out of the file, so nothing is trusted on its
                     // own: this record is held inside the font collection it belongs to,
                     // the count is bounded by the end of it, and each entry is told where
-                    // it has to stop.
+                    // it has to stop. The length and the count are four bytes each and are
+                    // read from the file as well, so there has to be room for them first.
+                    if (_start_supplemental + 8 > _end_rec)
+                    {
+                        s.Seek2(_end_rec);
+                        break;
+                    }
                     var _end_supplemental = Math.min(_start_supplemental + s.GetULong() + 4,
                         _end_rec, s.size);
                     var _count = s.GetULong();
-                    for (var i = 0; i < _count && s.cur < _end_supplemental; ++i)
+                    for (var i = 0; i < _count && s.cur + 1 < _end_supplemental; ++i)
                     {
                         s.Skip2(1); // type
                         var _font = this.ReadSupplementalFont(_end_supplemental);
@@ -5319,7 +5325,14 @@ function BinaryPPTYLoader()
         // GetString2 holds the length it reads against the end of the data, not against
         // the end of the record being read, so a corrupt one would pull in bytes that
         // belong to whatever follows. Give up on the record instead: seeking to its end
-        // also ends the loop this is called from.
+        // also ends the loop this is called from. The four bytes of the length can
+        // straddle the boundary themselves, so they are checked before being read.
+        if (s.cur + 4 > nEnd)
+        {
+            s.Seek2(nEnd);
+            return "";
+        }
+
         var nLen = s.GetULong();
         if (nLen < 0 || s.cur + 2 * nLen > nEnd)
         {
@@ -5335,9 +5348,18 @@ function BinaryPPTYLoader()
         var s = this.stream;
 
         var _rec_start = s.cur;
-        // The length is read from the file, so it is held to the end of the record this
-        // entry belongs to and to the end of the data: a corrupt one must not let an entry
-        // eat what follows it, or point beyond the stream.
+
+        // The four bytes of the length are read from the file too, so there has to be room
+        // for them inside the record this entry belongs to.
+        if (_rec_start + 4 > nEndLimit)
+        {
+            s.Seek2(Math.min(nEndLimit, s.size));
+            return { script: "", typeface: "" };
+        }
+
+        // The length itself is held to the end of that record and to the end of the data:
+        // a corrupt one must not let an entry eat what follows it, or point beyond the
+        // stream.
         var _end_rec = Math.min(_rec_start + s.GetULong() + 4, nEndLimit, s.size);
 
         var script = "";

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5297,6 +5297,15 @@ function BinaryPPTYLoader()
                     }
                     var _end_supplemental = Math.min(_start_supplemental + s.GetULong() + 4,
                         _end_rec, s.size);
+                    // A length that leaves no room for the count is not a record this can
+                    // read. Reading the count anyway would take four bytes from outside it
+                    // and then seek back over them, so what follows would be picked up a
+                    // second time as records of the font collection.
+                    if (s.cur + 4 > _end_supplemental)
+                    {
+                        s.Seek2(_end_rec);
+                        break;
+                    }
                     var _count = s.GetULong();
                     for (var i = 0; i < _count && s.cur + 1 < _end_supplemental; ++i)
                     {

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5251,6 +5251,11 @@ function BinaryPPTYLoader()
     {
         var s = this.stream;
 
+        // Cleared here rather than where record 3 is read, so that reading a collection
+        // that has no record 3 into a FontCollection that was used before leaves it with
+        // no entries instead of the previous ones.
+        fontcolls.clearSupplementalFont();
+
         var _rec_start = s.cur;
         // The record length is read from the file, so it is held to the end of the data as
         // well: past that GetUChar returns 0 without moving, and this loop would keep
@@ -5280,19 +5285,20 @@ function BinaryPPTYLoader()
                 case 3:
                 {
                     var _start_supplemental = s.cur;
-                    var _end_supplemental = _start_supplemental + s.GetULong() + 4;
-                    var _count = s.GetULong();
-                    fontcolls.clearSupplementalFont();
                     // Everything here comes out of the file, so nothing is trusted on its
-                    // own: the count is bounded by the end of the record as well, and each
-                    // entry is told where it has to stop.
+                    // own: this record is held inside the font collection it belongs to,
+                    // the count is bounded by the end of it, and each entry is told where
+                    // it has to stop.
+                    var _end_supplemental = Math.min(_start_supplemental + s.GetULong() + 4,
+                        _end_rec, s.size);
+                    var _count = s.GetULong();
                     for (var i = 0; i < _count && s.cur < _end_supplemental; ++i)
                     {
                         s.Skip2(1); // type
                         var _font = this.ReadSupplementalFont(_end_supplemental);
                         fontcolls.addSupplementalFont(_font.script, _font.typeface);
                     }
-                    s.Seek2(Math.min(_end_supplemental, s.size));
+                    s.Seek2(_end_supplemental);
                     break;
                 }
                 default:

--- a/common/Shapes/Serialize.js
+++ b/common/Shapes/Serialize.js
@@ -5307,7 +5307,10 @@ function BinaryPPTYLoader()
                         break;
                     }
                     var _count = s.GetULong();
-                    for (var i = 0; i < _count && s.cur + 1 < _end_supplemental; ++i)
+                    // An entry is a type byte and a four byte length before anything else,
+                    // so stop when what is left cannot hold one rather than add an empty
+                    // font for the remainder.
+                    for (var i = 0; i < _count && s.cur + 5 <= _end_supplemental; ++i)
                     {
                         s.Skip2(1); // type
                         var _font = this.ReadSupplementalFont(_end_supplemental);
@@ -5373,6 +5376,12 @@ function BinaryPPTYLoader()
 
         var script = "";
         var typeface = "";
+
+        if (s.cur >= _end_rec)
+        {
+            s.Seek2(_end_rec);
+            return { script: script, typeface: typeface };
+        }
 
         s.Skip2(1); // start attributes
 

--- a/common/Shapes/SerializeWriter.js
+++ b/common/Shapes/SerializeWriter.js
@@ -1628,6 +1628,18 @@ function CBinaryFileWriter()
         oThis.WriteRecord1(0, { Name: coll.latin, Index : -1 }, oThis.WriteTextFontTypeface);
         oThis.WriteRecord1(1, { Name: coll.ea, Index : -1 }, oThis.WriteTextFontTypeface);
         oThis.WriteRecord1(2, { Name: coll.cs, Index : -1 }, oThis.WriteTextFontTypeface);
+
+        if (coll.supplementalFont && coll.supplementalFont.length > 0)
+            oThis.WriteRecordArray(3, 0, coll.supplementalFont, oThis.WriteSupplementalFont);
+    };
+    this.WriteSupplementalFont = function(font)
+    {
+        oThis.WriteUChar(g_nodeAttributeStart);
+
+        oThis._WriteString1(0, font.script);
+        oThis._WriteString1(1, font.typeface);
+
+        oThis.WriteUChar(g_nodeAttributeEnd);
     };
     this.WriteFmtScheme = function(fmt)
     {

--- a/common/Shapes/test/supplementalfonts.html
+++ b/common/Shapes/test/supplementalfonts.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>theme supplemental font regression tests</title>
+		<script>
+			window.AscCommon = { c_dScalePPTXSizes: 36000 };
+			window.Asc = { c_oAscShdClear: 0, c_oAscColor: {}, c_oAscFill: {} };
+			window.AscFormat = {};
+			window.AscDFH = {};
+		</script>
+		<script src="./../../SerializeCommonWordExcel.js"></script>
+		<script src="./../SerializeWriter.js"></script>
+		<script src="./../Serialize.js"></script>
+		<script src="./supplementalfonts.js"></script>
+	</head>
+	<body onload="javascript: runSupplementalFontsTests();">
+		Results are written to the browser console.
+	</body>
+</html>

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -191,6 +191,40 @@
 		return bytes.subarray(0, bytes.length - 4);
 	}
 
+	/* Two entries, where the length in front of the first one's script has been made too
+	   long for the entry it sits in. The reader has to give up on that string rather than
+	   take in what comes after it. */
+	function writeWithOverlongString(markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.StartRecord(0);
+		writer.StartRecord(3);
+		writer.WriteULong(2);
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		var lengthAt = writer.GetCurPosition() + 1; /* after the attribute id */
+		writer._WriteString1(0, "AB");
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeEnd);
+		writer.EndRecord();
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		writer._WriteString1(0, "Hang");
+		writer._WriteString1(1, "Malgun Gothic");
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeEnd);
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.StartRecord(markerType);
+		writer.WriteULong(0);
+		writer.EndRecord();
+
+		var bytes = writer.GetData();
+		bytes[lengthAt] = 12; /* twelve characters do not fit in that entry */
+		bytes[lengthAt + 1] = 0;
+		bytes[lengthAt + 2] = 0;
+		bytes[lengthAt + 3] = 0;
+		return bytes;
+	}
+
 	/* Reads the collection back. Returns the reader so the caller can look at what
 	   follows the record. The byte reads are capped, so a parse that does not terminate
 	   fails a test rather than hanging the run. */
@@ -249,17 +283,26 @@
 		var marked = read(write(src, 7), new TestCollection());
 		check("stream is positioned after the record", marked.stream.GetUChar(), 7);
 
-		/* An attribute this build does not know leaves the rest of that entry misread -
-		   the two typefaces after it may or may not survive, so nothing is asserted about
-		   them - but the damage is contained: the entry is still counted, the named fonts
-		   are untouched, and the record that follows the font collection is still found.
-		   Reaching the end of the entry does depend on the parse landing on the end
-		   marker, which is how every attribute block in these files is read. */
+		/* The reader stops at an attribute it does not know, so the two typefaces written
+		   after it in this entry are always dropped. What has to hold is that the damage
+		   stops there: the entry is still counted, the named fonts are untouched, and the
+		   record after the font collection is still found. */
 		var oddColl = new TestCollection();
 		var oddLoader = read(writeWithUnknownAttribute(7), oddColl);
 		check("unknown attribute: entry still counted", oddColl.supplementalFont.length, 1);
 		check("unknown attribute: latin untouched", oddColl.latin, "Cambria");
 		check("unknown attribute: next record still found", oddLoader.stream.GetUChar(), 7);
+
+		/* A string longer than the entry holding it must not take in what follows. */
+		var longColl = new TestCollection();
+		var longLoader = read(writeWithOverlongString(7), longColl);
+		var longFirst = longColl.supplementalFont[0] || { script: "(no entry)" };
+		check("overlong string: entry count", longColl.supplementalFont.length, 2);
+		check("overlong string: nothing taken in from after the entry",
+			longFirst.script, "");
+		check("overlong string: the entry after it is untouched",
+			String(describe(longColl).split(",")[1]), "Hang=Malgun Gothic");
+		check("overlong string: next record still found", longLoader.stream.GetUChar(), 7);
 
 		/* An attribute block that never ends has to stop at the end of its entry, rather
 		   than look for an end marker that is not there. */

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -255,6 +255,30 @@
 		return bytes;
 	}
 
+	/* One entry, a count claiming two, and three bytes of rubbish where the second entry
+	   should be - too few to hold even a type byte and a length. */
+	function writeWithStrayTail(markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.StartRecord(0);
+		writer.StartRecord(3);
+		writer.WriteULong(2);
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		writer._WriteString1(0, "Jpan");
+		writer._WriteString1(1, "MS PGothic");
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeEnd);
+		writer.EndRecord();
+		writer.WriteUChar(0);
+		writer.WriteUChar(0);
+		writer.WriteUChar(0);
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.StartRecord(markerType);
+		writer.WriteULong(0);
+		writer.EndRecord();
+		return writer.GetData();
+	}
+
 	/* Reads the collection back. Returns the reader so the caller can look at what
 	   follows the record. The byte reads are capped, so a parse that does not terminate
 	   fails a test rather than hanging the run. */
@@ -345,6 +369,14 @@
 			check("record 3 of length " + shortLen + ": next record still found",
 				shortLoader ? shortLoader.stream.GetUChar() : -1, 7);
 		}
+
+		/* A tail too short to be an entry is left alone rather than turned into an empty
+		   font, even though the count says another entry is there. */
+		var tailColl = new TestCollection();
+		var tailLoader = read(writeWithStrayTail(7), tailColl);
+		check("stray tail: only the real entry is kept", tailColl.supplementalFont.length, 1);
+		check("stray tail: that entry is intact", describe(tailColl), "Jpan=MS PGothic");
+		check("stray tail: next record still found", tailLoader.stream.GetUChar(), 7);
 
 		/* A string longer than the entry holding it must not take in what follows. */
 		var longColl = new TestCollection();

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/*
+ * Regression tests for the <a:font script="..."/> entries of a theme font collection
+ * (record 3 of a FontCollection) through the PPTY writer and reader.
+ *
+ * From this directory:  node supplementalfonts.js   (exit code 1 if anything fails)
+ * Or open supplementalfonts.html and read the browser console.
+ *
+ * The record layout under test is the one the C++ side writes, in
+ * core/OOXML/PPTXFormat/Logic/{FontCollection,SupplementalFont}.cpp: record 3 holds a
+ * count followed by that many subrecords of type 0, each an attribute block with
+ * 0 = script and 1 = typeface.
+ */
+(function () {
+	"use strict";
+
+	/* Decided up front: the node branch below defines window, so this cannot be
+	   re-tested later on. */
+	var isNode = (typeof window === "undefined");
+	var root;
+	if (!isNode) {
+		/* The html page has already set up the namespaces and loaded the sources. */
+		root = window;
+	} else {
+		/* Under node, give the sources the globals they write into, then load them. */
+		root = global;
+		root.window = root;
+		root.AscCommon = root.AscCommon || {};
+		root.Asc = root.Asc || {};
+		root.AscFormat = root.AscFormat || {};
+		root.AscDFH = root.AscDFH || {};
+		root.AscCommon.c_dScalePPTXSizes = 36000;
+		root.Asc.c_oAscShdClear = 0;
+		root.Asc.c_oAscColor = {};
+		root.Asc.c_oAscFill = {};
+		require("../../SerializeCommonWordExcel.js");
+		require("../SerializeWriter.js");
+		require("../Serialize.js");
+	}
+
+	var failures = 0, total = 0;
+
+	function log(s) {
+		if (typeof console !== "undefined" && console.log) {
+			console.log(s);
+		}
+	}
+
+	function check(name, actual, expected) {
+		total++;
+		var ok = (actual === expected);
+		if (!ok) {
+			failures++;
+		}
+		log((ok ? "PASS  " : "FAIL  ") + name + "   got " + actual + ", expected " + expected);
+	}
+
+	/* AscFormat.FontCollection does not load outside the editor, so the tests use a
+	   stand-in carrying only what the reader and the writer touch. The code under test
+	   is the real writer and the real reader. */
+	function TestCollection() {
+		this.latin = null;
+		this.ea = null;
+		this.cs = null;
+		this.supplementalFont = [];
+	}
+	TestCollection.prototype.setLatin = function (v) { this.latin = v; };
+	TestCollection.prototype.setEA = function (v) { this.ea = v; };
+	TestCollection.prototype.setCS = function (v) { this.cs = v; };
+	TestCollection.prototype.addSupplementalFont = function (script, typeface) {
+		this.supplementalFont.push({ script: script, typeface: typeface });
+	};
+
+	function makeCollection(fonts) {
+		var coll = new TestCollection();
+		coll.latin = "Cambria";
+		coll.ea = "";
+		coll.cs = "";
+		for (var i = 0; i < fonts.length; ++i) {
+			coll.addSupplementalFont(fonts[i][0], fonts[i][1]);
+		}
+		return coll;
+	}
+
+	function describe(coll) {
+		var parts = [];
+		for (var i = 0; i < coll.supplementalFont.length; ++i) {
+			parts.push(coll.supplementalFont[i].script + "=" + coll.supplementalFont[i].typeface);
+		}
+		return parts.join(",");
+	}
+
+	/* Writes the collection as record 0, plus an optional marker record after it, and
+	   returns the bytes. */
+	function write(coll, markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.WriteRecord1(0, coll, writer.WriteFontCollection);
+		if (undefined !== markerType) {
+			writer.StartRecord(markerType);
+			writer.WriteULong(0);
+			writer.EndRecord();
+		}
+		return writer.GetData();
+	}
+
+	/* The same record, but with an attribute this build does not know placed before the
+	   two it does. Hand-built, because the writer only ever emits known attributes. */
+	function writeWithUnknownAttribute(markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.StartRecord(0);
+		writer.WriteRecord1(0, { Name: "Cambria", Index: -1 }, writer.WriteTextFontTypeface);
+		writer.StartRecord(3);
+		writer.WriteULong(1);
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		writer._WriteString1(9, "unknown-attribute-value");
+		writer._WriteString1(0, "Jpan");
+		writer._WriteString1(1, "MS PGothic");
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeEnd);
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.StartRecord(markerType);
+		writer.WriteULong(0);
+		writer.EndRecord();
+		return writer.GetData();
+	}
+
+	/* The same again, but with the attribute block left unterminated. Past the end of the
+	   data FileStream.GetUChar keeps returning 0, so a parser that reads on until it sees
+	   an end marker never finishes on input like this. */
+	function writeWithoutEndMarker(markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.StartRecord(0);
+		writer.WriteRecord1(0, { Name: "Cambria", Index: -1 }, writer.WriteTextFontTypeface);
+		writer.StartRecord(3);
+		writer.WriteULong(1);
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		writer._WriteString1(9, "aaaaaaaaaaaaaaaa");
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.StartRecord(markerType);
+		writer.WriteULong(0);
+		writer.EndRecord();
+		return writer.GetData();
+	}
+
+	/* Reads the collection back. Returns the reader so the caller can look at what
+	   follows the record. The byte reads are capped, so a parse that does not terminate
+	   fails a test rather than hanging the run. */
+	function read(bytes, coll) {
+		var loader = new root.AscCommon.BinaryPPTYLoader();
+		var stream = new root.AscCommon.FileStream(bytes, bytes.length);
+		loader.stream = stream;
+		stream.GetUChar(); /* the record type written above */
+
+		var reads = 0;
+		var readByte = stream.GetUChar;
+		stream.GetUChar = function () {
+			if (++reads > 100000) {
+				throw new Error("the parse did not terminate");
+			}
+			return readByte.apply(stream, arguments);
+		};
+		try {
+			loader.ReadFontCollection(coll);
+		} finally {
+			stream.GetUChar = readByte;
+		}
+		return loader;
+	}
+
+	function run() {
+		var fonts = [["Jpan", "ＭＳ Ｐゴシック"],
+			["Hang", "맑은 고딕"],
+			["Hans", "宋体"],
+			["Hant", "新細明體"],
+			["Arab", "Times New Roman"]];
+
+		/* The case this was written for: the per-script fonts of a theme have to come
+		   back out of the round trip. Without them an application has nothing but the
+		   latin font to fall back on for East Asian text. */
+		var src = makeCollection(fonts);
+		var dst = new TestCollection();
+		read(write(src), dst);
+		check("script fonts survive the round trip", describe(dst), describe(src));
+		check("script font count", dst.supplementalFont.length, fonts.length);
+
+		/* The three named fonts must be unaffected. */
+		check("latin survives", dst.latin, "Cambria");
+		check("ea survives", dst.ea, "");
+		check("cs survives", dst.cs, "");
+
+		/* A collection with no script fonts stays empty, and must not upset the reader. */
+		var empty = makeCollection([]);
+		var emptyBack = new TestCollection();
+		read(write(empty), emptyBack);
+		check("no script fonts stays empty", emptyBack.supplementalFont.length, 0);
+		check("latin survives without script fonts", emptyBack.latin, "Cambria");
+
+		/* The reader has to leave the stream at the end of record 3, or everything after
+		   the font collection is read from the wrong offset. */
+		var marked = read(write(src, 7), new TestCollection());
+		check("stream is positioned after the record", marked.stream.GetUChar(), 7);
+
+		/* An attribute this build does not know leaves the rest of that entry misread -
+		   the two typefaces after it may or may not survive, so nothing is asserted about
+		   them - but the damage is contained: the entry is still counted, the named fonts
+		   are untouched, and the record that follows the font collection is still found.
+		   Reaching the end of the entry does depend on the parse landing on the end
+		   marker, which is how every attribute block in these files is read. */
+		var oddColl = new TestCollection();
+		var oddLoader = read(writeWithUnknownAttribute(7), oddColl);
+		check("unknown attribute: entry still counted", oddColl.supplementalFont.length, 1);
+		check("unknown attribute: latin untouched", oddColl.latin, "Cambria");
+		check("unknown attribute: next record still found", oddLoader.stream.GetUChar(), 7);
+
+		/* And the reader has to give up on an attribute block that never ends, rather than
+		   look for an end marker that is not there. */
+		var truncColl = new TestCollection();
+		var truncLoader = null;
+		try {
+			truncLoader = read(writeWithoutEndMarker(7), truncColl);
+		} catch (e) {
+			log("  (" + e.message + ")");
+		}
+		check("unterminated block: the parse stops", null !== truncLoader, true);
+		check("unterminated block: next record still found",
+			truncLoader ? truncLoader.stream.GetUChar() : -1, 7);
+
+		/* The record layout itself, as the C++ writer produces it: type 3, then the
+		   record length, then the number of entries. */
+		var bytes = write(src);
+		var at = -1;
+		for (var i = 0; i + 8 < bytes.length; ++i) {
+			if (3 === bytes[i] && fonts.length === bytes[i + 5] &&
+				0 === bytes[i + 6] && 0 === bytes[i + 7] && 0 === bytes[i + 8]) {
+				at = i;
+				break;
+			}
+		}
+		check("record 3 carries the entry count", at >= 0, true);
+
+		log("");
+		log(failures ? (failures + " of " + total + " failed") : ("all " + total + " passed"));
+		return failures;
+	}
+
+	if (isNode) {
+		process.exitCode = run() ? 1 : 0;
+	} else {
+		root.runSupplementalFontsTests = run;
+	}
+})();

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -225,6 +225,36 @@
 		return bytes;
 	}
 
+	/* A record 3 whose declared length is too short to hold even its own count. Reading the
+	   count anyway takes four bytes from outside the record and then seeks back over them,
+	   so the bytes after it get picked up a second time as records of the font collection -
+	   which is how a crafted file reaches the readers for those records. */
+	function writeWithShortSupplementalRecord(declaredLength, markerType) {
+		var writer = new root.AscCommon.CBinaryFileWriter();
+		writer.StartRecord(0);
+		var typeAt = writer.GetCurPosition(); /* the record 3 type byte */
+		writer.StartRecord(3);
+		writer.WriteULong(1);
+		writer.StartRecord(0);
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
+		writer._WriteString1(0, "Jpan");
+		writer._WriteString1(1, "MS PGothic");
+		writer.WriteUChar(root.AscCommon.g_nodeAttributeEnd);
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.EndRecord();
+		writer.StartRecord(markerType);
+		writer.WriteULong(0);
+		writer.EndRecord();
+
+		var bytes = writer.GetData();
+		bytes[typeAt + 1] = declaredLength; /* the four length bytes follow the type */
+		bytes[typeAt + 2] = 0;
+		bytes[typeAt + 3] = 0;
+		bytes[typeAt + 4] = 0;
+		return bytes;
+	}
+
 	/* Reads the collection back. Returns the reader so the caller can look at what
 	   follows the record. The byte reads are capped, so a parse that does not terminate
 	   fails a test rather than hanging the run. */
@@ -292,6 +322,29 @@
 		check("unknown attribute: entry still counted", oddColl.supplementalFont.length, 1);
 		check("unknown attribute: latin untouched", oddColl.latin, "Cambria");
 		check("unknown attribute: next record still found", oddLoader.stream.GetUChar(), 7);
+
+		/* A record too short for its own count is skipped whole, so nothing inside it is
+		   handed to the readers for the other records of the collection. `latin` staying
+		   untouched is what shows that: without this, the leftover bytes were read as a
+		   record 0 and went through ReadTextFontTypeface. */
+		for (var shortLen = 0; shortLen < 4; ++shortLen) {
+			var shortColl = new TestCollection();
+			var shortLoader = null;
+			try {
+				shortLoader = read(writeWithShortSupplementalRecord(shortLen, 7), shortColl);
+			} catch (e) {
+				/* Without the check, this reaches ReadTextFontTypeface, which reads until it
+				   sees an end marker and never finds one. */
+				log("  (" + e.message + ")");
+			}
+			check("record 3 of length " + shortLen + ": the parse stops", null !== shortLoader, true);
+			check("record 3 of length " + shortLen + ": no entries",
+				shortColl.supplementalFont.length, 0);
+			check("record 3 of length " + shortLen + ": nothing re-read as another record",
+				shortColl.latin, null);
+			check("record 3 of length " + shortLen + ": next record still found",
+				shortLoader ? shortLoader.stream.GetUChar() : -1, 7);
+		}
 
 		/* A string longer than the entry holding it must not take in what follows. */
 		var longColl = new TestCollection();

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -101,6 +101,9 @@
 	TestCollection.prototype.setLatin = function (v) { this.latin = v; };
 	TestCollection.prototype.setEA = function (v) { this.ea = v; };
 	TestCollection.prototype.setCS = function (v) { this.cs = v; };
+	TestCollection.prototype.clearSupplementalFont = function () {
+		this.supplementalFont.length = 0;
+	};
 	TestCollection.prototype.addSupplementalFont = function (script, typeface) {
 		this.supplementalFont.push({ script: script, typeface: typeface });
 	};
@@ -160,9 +163,11 @@
 		return writer.GetData();
 	}
 
-	/* The same again, but with the attribute block left unterminated. Past the end of the
-	   data FileStream.GetUChar keeps returning 0, so a parser that reads on until it sees
-	   an end marker never finishes on input like this. */
+	/* The same again, but with the attribute block left unterminated after an attribute the
+	   reader does know. Past the end of the data FileStream.GetUChar returns 0, which is a
+	   valid attribute id, so a parser that reads until it sees the end marker spins there
+	   for ever. Pass a marker record type to put a record after the collection, or nothing
+	   to cut the data off inside the entry. */
 	function writeWithoutEndMarker(markerType) {
 		var writer = new root.AscCommon.CBinaryFileWriter();
 		writer.StartRecord(0);
@@ -171,14 +176,19 @@
 		writer.WriteULong(1);
 		writer.StartRecord(0);
 		writer.WriteUChar(root.AscCommon.g_nodeAttributeStart);
-		writer._WriteString1(9, "aaaaaaaaaaaaaaaa");
+		writer._WriteString1(0, "Jpan");
 		writer.EndRecord();
 		writer.EndRecord();
 		writer.EndRecord();
-		writer.StartRecord(markerType);
-		writer.WriteULong(0);
-		writer.EndRecord();
-		return writer.GetData();
+		if (undefined !== markerType) {
+			writer.StartRecord(markerType);
+			writer.WriteULong(0);
+			writer.EndRecord();
+			return writer.GetData();
+		}
+		/* No marker: hand back a short stream, so the parse runs into the end of the data. */
+		var bytes = writer.GetData();
+		return bytes.subarray(0, bytes.length - 4);
 	}
 
 	/* Reads the collection back. Returns the reader so the caller can look at what
@@ -251,18 +261,36 @@
 		check("unknown attribute: latin untouched", oddColl.latin, "Cambria");
 		check("unknown attribute: next record still found", oddLoader.stream.GetUChar(), 7);
 
-		/* And the reader has to give up on an attribute block that never ends, rather than
-		   look for an end marker that is not there. */
-		var truncColl = new TestCollection();
-		var truncLoader = null;
+		/* An attribute block that never ends has to stop at the end of its entry, rather
+		   than look for an end marker that is not there. */
+		var openColl = new TestCollection();
+		var openLoader = null;
 		try {
-			truncLoader = read(writeWithoutEndMarker(7), truncColl);
+			openLoader = read(writeWithoutEndMarker(7), openColl);
 		} catch (e) {
 			log("  (" + e.message + ")");
 		}
-		check("unterminated block: the parse stops", null !== truncLoader, true);
+		check("unterminated block: the parse stops", null !== openLoader, true);
 		check("unterminated block: next record still found",
-			truncLoader ? truncLoader.stream.GetUChar() : -1, 7);
+			openLoader ? openLoader.stream.GetUChar() : -1, 7);
+
+		/* And the same with the data cut off inside the entry, so there is no marker to
+		   find and nothing after the record either. */
+		var cutColl = new TestCollection();
+		var cutStopped = true;
+		try {
+			read(writeWithoutEndMarker(), cutColl);
+		} catch (e) {
+			cutStopped = false;
+			log("  (" + e.message + ")");
+		}
+		check("unterminated block at end of data: the parse stops", cutStopped, true);
+
+		/* Reading a second time replaces the entries rather than appending to them. */
+		var reloaded = new TestCollection();
+		read(write(src), reloaded);
+		read(write(src), reloaded);
+		check("reading twice does not accumulate", reloaded.supplementalFont.length, fonts.length);
 
 		/* The record layout itself, as the C++ writer produces it: type 3, then the
 		   record length, then the number of entries. */

--- a/common/Shapes/test/supplementalfonts.js
+++ b/common/Shapes/test/supplementalfonts.js
@@ -286,11 +286,15 @@
 		}
 		check("unterminated block at end of data: the parse stops", cutStopped, true);
 
-		/* Reading a second time replaces the entries rather than appending to them. */
+		/* Reading a second time replaces the entries rather than adding to them, and a
+		   collection that carries no record 3 at all leaves none behind either. */
 		var reloaded = new TestCollection();
 		read(write(src), reloaded);
 		read(write(src), reloaded);
 		check("reading twice does not accumulate", reloaded.supplementalFont.length, fonts.length);
+		read(write(makeCollection([])), reloaded);
+		check("reading one without script fonts clears the previous ones",
+			reloaded.supplementalFont.length, 0);
 
 		/* The record layout itself, as the C++ writer produces it: type 3, then the
 		   record length, then the number of entries. */


### PR DESCRIPTION
Relates to ONLYOFFICE/DocumentServer#1415.

Opening a file and saving it drops every `<a:font script="..."/>` entry from the theme's
`fontScheme`. The default Office theme carries 94 of them - 47 in `majorFont`, 47 in
`minorFont` - so a document or workbook created anywhere loses them the first time it is
saved, and reopening the file does not bring them back. Word and Excel then have nothing
but `<a:latin>` to fall back on for East Asian, Arabic, Hebrew, Indic and the other forty
scripts covered by the theme.

The data reaches the editor intact: `FontCollection::toPPTY` in
`core/OOXML/PPTXFormat/Logic/FontCollection.cpp` already writes it as record 3, and
`SupplementalFont::toPPTY` writes each entry as an attribute block with `0 = script` and
`1 = typeface`. Only the JS side drops it.

## Changes

**`common/Shapes/Serialize.js` - `ReadFontCollection`**

Record 3 was read and discarded (`var _len = s.GetULong(); s.Skip2(_len);`). It is now
parsed: the count, then that many subrecords, each handed to a new `ReadSupplementalFont`
written the same way as the neighbouring `ReadTextFontTypeface`. The reader seeks to the
end of the record when it is done, so anything following the font collection is still read
from the right offset.

This replaces a plain skip with a parse, so nothing the parse reads is trusted on its own.
Every length and count here comes out of the file:

- The font collection's own record length is held to the end of the data, record 3 is held
  inside that, and the entry count is held to the end of record 3, so a corrupt one of any
  of them cannot walk the reader past where it belongs. A length or a count is four bytes
  read from the file as well, so there has to be room for those four bytes before they are
  read. A record 3 too short to hold its own count is skipped whole - reading the count
  anyway would take it from outside the record and then seek back over those bytes, and
  what followed would be read a second time as records of the collection.
- Each entry is told where it has to stop, and its own length is clamped to that and to the
  end of the data, so a corrupt entry cannot eat the entries after it. An entry needs a type
  byte and a length before anything else, so a tail too short for that ends the loop instead
  of becoming an empty font.
- `ReadSupplementalFont` stops at the first attribute it does not know. An unknown attribute
  has no length in front of it, so its value cannot be stepped over and reading on would be
  out of step. What is dropped is any attribute after the unknown one, which the tests
  cover.
- The attribute loop ends at the end of the entry, and also if a read leaves the position
  where it was. Both are needed: past the end of the data `GetUChar` returns `0`, which is
  a valid attribute id, and `GetULong` stops without moving when fewer than four bytes are
  left, so the position can stall short of the boundary.
- Strings are read through `ReadStringInRecord` rather than `GetString2`, which holds its
  length against the end of the data and not against the end of the record. A length too
  long for the entry it sits in would otherwise pull the bytes after it into the value.

Between them the parse stops, stays inside the entry it is reading, and leaves the position
on the record boundary.

`ReadTextFontTypeface` and the other attribute readers read until they see an end marker
and do not stop at the end of their record or at the end of the data, so a corrupt font
collection can still put one of them in a loop that does not finish. That is how master
behaves today and this patch does not change it - see the numbers under Testing. Bounding
them is a wider change and each would want its own test, so they are untouched here.

**`common/Drawings/Format/Format.js` - `FontCollection`**

Added a `supplementalFont` array and a small `SupplementalFont` holding `script` and
`typeface`, so there is somewhere to put what was read, plus `clearSupplementalFont`, which
the reader calls before it starts so that loading a second theme replaces the entries rather
than adding to them - including a theme that carries no record 3 at all.
`FontScheme.createDuplicate` copies them. `Write_ToBinary` / `Read_FromBinary` deliberately
do not - see Compatibility below.

**`common/Shapes/SerializeWriter.js` - `WriteFontCollection`**

Writes record 3 back out when the collection has any entries, using `WriteRecordArray(3, 0,
...)` - the same call the C++ writer makes.

**`common/Shapes/test/supplementalfonts.js`, `common/Shapes/test/supplementalfonts.html`** - new

Forty assertions over `WriteFontCollection` and `ReadFontCollection`, laid out like the
existing `common/geometry/test` and `common/libfont/test`. From `common/Shapes/test`,
`node supplementalfonts.js` prints the results and exits 1 if anything fails; it sets up
the globals the sources write into and loads them itself, so nothing else is needed. The
html page does the same in a browser and writes to the console. Sixteen of the 40
assertions fail on master and all 40 pass after this change. The byte-read cap ensures that a
non-terminating regression fails the test instead of hanging it.

The scope is the writer and the reader. `AscFormat.FontCollection` does not load outside
the editor, so the tests drive a stand-in carrying only what those two touch: the reader's
use of `clearSupplementalFont` and `addSupplementalFont` is covered, but `setSupplementalFont`
and `FontScheme.createDuplicate` are not. If you have an integration harness where a theme
can be read into a real `FontCollection`, duplicated and written back out, that is the test
worth adding and I am happy to write it against it.

## Compatibility

The PPTY file format is forward-compatible: older *file* readers already skip record 3, so
a binary written by a patched build is read by an unpatched one exactly as before, minus
the entries.

This does not apply to the separate history format. `FontScheme.Write_ToBinary` is a bare
concatenation - `majorFont`, `minorFont`, then the name - with no length framing, so a
field added inside a `FontCollection` does not merely leave a reader short: an unpatched
reader would start reading `minorFont` from the middle of the new count, and a patched
reader would take the first bytes of `minorFont` in an old stream as a count. It breaks in
both directions. To avoid changing that wire format, this PR intentionally does not
serialize `supplementalFont` through `Write_ToBinary` / `Read_FromBinary`.

In-process undo/redo retains these entries through the Old/New object references. They are
not preserved after a font-scheme replacement is serialized through the history/collaboration
binary format, so a client receiving that change over co-editing would lose them.

Carrying them through history properly would need explicit versioning or length framing in
that protocol plus mixed-version tests, which felt like a separate change from fixing the
file round trip.

## Deliberately not changed

**Rendering.** ONLYOFFICE resolves a `scheme="minor"` font to `<a:latin>` and never
consults the `script` entries, so East Asian text is still drawn with a font that has no
glyphs for it - the first screenshot in DocumentServer#1415, and the same shape as
DocumentServer#3539 for `<a:cs>`. This patch changes what is stored, not what is drawn. A
file saved with it applied renders correctly in Word again; ONLYOFFICE's own rendering is
unchanged.

**`<a:ea typeface=""/>` becoming `"Arial"`.** Visible in the same screenshot, but it
happens earlier and on the C++ side - `GetTypefacePickByName()` in
`core/OOXML/Binary/Presentation/FontPicker.cpp` substitutes `Arial` for an empty typeface
before sdkjs sees it. Out of scope here.

**JSON serialization.** `SerFontCollection` and `FontCollectionFromJSON` in
`word/fromToJSON.js` carry `latin`, `ea` and `cs` only, so a theme taken through
`ApiThemeFontScheme.ToJSON()` and back still loses these entries. That is not the OOXML or
PPTY path this fixes; say the word and I will extend it here or open it separately.

## Testing

- `common/Shapes/test/supplementalfonts.js`: 16 of 40 fail on master, 40 of 40 pass after. Same
  results from the html page in a browser.
- A workbook carrying the Cambria/Calibri "Office" theme - the reproducer's theme, 60
  entries - opened in Desktop Editors 9.4.0, edited and saved: 60 entries become 0 on a
  stock bundle, and stay at 60 - same values, same order - with this applied. Undoing and
  redoing the cell change before saving does not disturb them either. `2.docx` attached to DocumentServer#1415 behaves the same
  way. Receiving or replaying a *serialized* font-scheme replacement is the case the
  Compatibility note above excludes, and is not covered by this.
- Local exploratory fuzzing, 200,000 cases. A font collection carrying three script fonts
  and no `latin`/`ea`/`cs` record, one to five bytes replaced at a time inside record 3
  from a fixed seed, leaving its type byte alone; a run counts as not terminating when it
  passes 50,000 byte reads, and as re-read when any of `latin`, `ea` or `cs` comes back
  set, since only bytes from inside record 3 could have produced one. The script is not in
  the PR:

  | | re-read as another record | does not terminate |
  | --- | --- | --- |
  | master | 7434 | 1216 |
  | `a7eed85` | 1217 | 136 |

  What is left is a record 3 that declares a length shorter than what it holds: the rest is
  then a sibling record by the rules of the format, and reading it can reach the unbounded
  attribute readers described above. That path is master's, not this patch's; the patch
  narrows it rather than opening it.
- `build/build.py --product cell|word|slide --desktop` all succeed.
- macOS 26.6, Apple Silicon, Desktop Editors 9.4.0. Not tested on Document Server or the
  Docker image.
