### PR TITLE
Reach the complex script font slot for DrawingML text

### DIFF
--- a/word/Editor/Paragraph/TextShaper.js
+++ b/word/Editor/Paragraph/TextShaper.js
@@ -107,6 +107,41 @@
 		if (!oTextPr)
 			return AscWord.fontslot_None;
 
+		// DrawingML text properties (<a:rPr>) have no counterpart to <w:cs/> and <w:rtl/>,
+		// so complex script text can never reach fontslot_CS through the explicit flags
+		// and always falls back to the Latin font. Select the slot from the character for
+		// that content only. WordprocessingML keeps its flag driven behaviour, which
+		// matches how MS Word resolves the slots.
+		//
+		// Restricted to the scripts measured against PowerPoint. Hebrew, Arabic and
+		// Syriac are drawn with <a:cs> there; Thaana is not, even though it is also
+		// right-to-left, so a plain right-to-left test would be too wide.
+		if (this.Paragraph
+			&& false === this.Paragraph.bFromDocument
+			&& !oTextPr.CS
+			&& !oTextPr.RTL)
+		{
+			// The same classification the shaper uses to split segments, so the slot
+			// cannot change in the middle of one. It also folds U+060C..U+074A into
+			// Arabic, which is why most Syriac arrives here as Arabic and the Syriac
+			// branch below covers the Syriac Supplement block.
+			let nScript = this.GetTextScript(nUnicode);
+
+			// Combining marks carry no script of their own. Deciding per code point
+			// would put an Arabic base in the CS slot and its vowel marks in the ASCII
+			// slot, and a font change flushes the shaping buffer - the marks would be
+			// shaped apart from the letter they belong to. Continue the script of the
+			// segment being shaped instead, the same way this.Script is carried forward
+			// in private_CheckNewSegment.
+			if (AscFonts.HB_SCRIPT.HB_SCRIPT_INHERITED === nScript)
+				nScript = this.Script;
+
+			if (AscFonts.HB_SCRIPT.HB_SCRIPT_HEBREW === nScript
+				|| AscFonts.HB_SCRIPT.HB_SCRIPT_ARABIC === nScript
+				|| AscFonts.HB_SCRIPT.HB_SCRIPT_SYRIAC === nScript)
+				return AscWord.fontslot_CS;
+		}
+
 		return AscWord.GetFontSlotByTextPr(nUnicode, oTextPr);
 	};
 	CParagraphTextShaper.prototype.GetLigaturesType = function(textScript)

--- a/word/Editor/Paragraph/TextShaper.js
+++ b/word/Editor/Paragraph/TextShaper.js
@@ -113,9 +113,10 @@
 		// that content only. WordprocessingML keeps its flag driven behaviour, which
 		// matches how MS Word resolves the slots.
 		//
-		// Restricted to the scripts measured against PowerPoint. Hebrew, Arabic and
-		// Syriac are drawn with <a:cs> there; Thaana is not, even though it is also
-		// right-to-left, so a plain right-to-left test would be too wide.
+		// Restricted to the four scripts measured against PowerPoint: Hebrew, Arabic,
+		// Syriac and Thaana are drawn with <a:cs> there. That is as far as the
+		// measurements go, so no rule is generalised from them - adding a fifth script
+		// should mean measuring it first.
 		if (this.Paragraph
 			&& false === this.Paragraph.bFromDocument
 			&& !oTextPr.CS
@@ -138,7 +139,8 @@
 
 			if (AscFonts.HB_SCRIPT.HB_SCRIPT_HEBREW === nScript
 				|| AscFonts.HB_SCRIPT.HB_SCRIPT_ARABIC === nScript
-				|| AscFonts.HB_SCRIPT.HB_SCRIPT_SYRIAC === nScript)
+				|| AscFonts.HB_SCRIPT.HB_SCRIPT_SYRIAC === nScript
+				|| AscFonts.HB_SCRIPT.HB_SCRIPT_THAANA === nScript)
 				return AscWord.fontslot_CS;
 		}
 

--- a/word/Editor/Paragraph/test/fontslot.html
+++ b/word/Editor/Paragraph/test/fontslot.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Font slot selection</title>
+
+    <script type="text/javascript" src="./../../../../common/libfont/common.js"></script>
+
+    <script type="text/javascript">
+        // The lookup table in FontClassification.js is allocated through
+        // AscFonts.allocate, which the font engine normally provides. This page
+        // loads no fonts and measures nothing, so the one line body from
+        // common/libfont/loader.js is enough and the engine is left out.
+        window['AscFonts'] = window['AscFonts'] || {};
+        window['AscFonts'].allocate = function(size) { return new Uint8Array(size); };
+    </script>
+
+    <script type="text/javascript" src="./../../../../common/commonDefines.js"></script>
+    <script type="text/javascript" src="./../Run/FontClassification.js"></script>
+    <script type="text/javascript" src="./../../../../common/libfont/textshaper.js"></script>
+    <script type="text/javascript" src="./../../../../common/libfont/stringshaper.js"></script>
+    <script type="text/javascript" src="./../TextShaper.js"></script>
+</head>
+
+<body style="font-family: monospace; font-size: 13px; padding: 16px;">
+    <h3 style="margin-top: 0;">CParagraphTextShaper.GetFontSlot</h3>
+    <script type="text/javascript" src="./fontslot.js"></script>
+</body>
+
+</html>

--- a/word/Editor/Paragraph/test/fontslot.js
+++ b/word/Editor/Paragraph/test/fontslot.js
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. For
+ * details, see the GNU AGPL at: https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA by email at info@onlyoffice.com
+ * or by postal mail at 20A-6 Ernesta Birznieka-Upisha Street, Riga,
+ * LV-1050, Latvia, European Union.
+ *
+ * The interactive user interfaces in modified versions of the Program
+ * are required to display Appropriate Legal Notices in accordance with
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * No trademark rights are granted under this License.
+ *
+ * All non-code elements of the Product, including illustrations,
+ * icon sets, and technical writing content, are licensed under the
+ * Creative Commons Attribution-ShareAlike 4.0 International License:
+ * https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ * This license applies only to such non-code elements and does not
+ * modify or replace the licensing terms applicable to the Program's
+ * source code, which remains licensed under the GNU Affero General
+ * Public License v3.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Font slot selection in CParagraphTextShaper.GetFontSlot.
+ *
+ * The point of interest is that DrawingML text has no <w:cs/> or <w:rtl/> to
+ * decide with, so the slot is taken from the character there and only there.
+ * These tests pin both halves of that: the DrawingML behaviour and the
+ * WordprocessingML behaviour that must not change.
+ *
+ * No fonts are loaded and nothing is measured - GetFontSlot is a pure decision
+ * over a code point and the run properties, so the shaper is driven directly.
+ *
+ * Open fontslot.html in a browser, or run this file with node:
+ *   node word/Editor/Paragraph/test/fontslot.js
+ */
+(function(root)
+{
+	"use strict";
+
+	if (typeof require === "function" && typeof module === "object")
+	{
+		// node: load the same sources the html page loads
+		root.window = root;
+		let path = require("path");
+		let sdk  = path.resolve(__dirname, "../../../..");
+		require(path.join(sdk, "common/libfont/common.js"));
+		// loader.js needs a document to build its canvas, so out of a browser
+		// only the one function the lookup table needs is taken from it. This
+		// is the same body, see AscFonts.allocate in common/libfont/loader.js.
+		root.AscFonts.allocate = function(size) { return new Uint8Array(size); };
+		require(path.join(sdk, "common/commonDefines.js"));
+		require(path.join(sdk, "word/Editor/Paragraph/Run/FontClassification.js"));
+		require(path.join(sdk, "common/libfont/textshaper.js"));
+		require(path.join(sdk, "common/libfont/stringshaper.js"));
+		require(path.join(sdk, "word/Editor/Paragraph/TextShaper.js"));
+	}
+
+	let AscWord  = root.AscWord;
+	let AscFonts = root.AscFonts;
+	let SCRIPT   = AscFonts.HB_SCRIPT;
+
+	const SLOT_NAME = {};
+	SLOT_NAME[AscWord.fontslot_None]     = "None";
+	SLOT_NAME[AscWord.fontslot_ASCII]    = "ASCII";
+	SLOT_NAME[AscWord.fontslot_EastAsia] = "EastAsia";
+	SLOT_NAME[AscWord.fontslot_HAnsi]    = "HAnsi";
+	SLOT_NAME[AscWord.fontslot_CS]       = "CS";
+
+	/**
+	 * Minimal stand-in for the compiled text properties. GetFontSlotByTextPr
+	 * reads exactly these four values.
+	 */
+	function textPr(isCS, isRTL)
+	{
+		return {
+			CS     : !!isCS,
+			RTL    : !!isRTL,
+			RFonts : {Hint : AscWord.fonthint_Default},
+			Lang   : {EastAsia : 0x0409}
+		};
+	}
+
+	/**
+	 * @param nUnicode   code point under test
+	 * @param isDrawing  true for <a:txBody> content, false for a document body
+	 * @param oTextPr    run properties
+	 * @param nScript    script of the segment being shaped (-1 when it has not
+	 *                   started yet). Only reached by marks and joiners.
+	 */
+	function slotOf(nUnicode, isDrawing, oTextPr, nScript)
+	{
+		let shaper = AscWord.ParagraphTextShaper;
+		shaper.Paragraph = {bFromDocument : !isDrawing};
+		shaper.TextPr    = oTextPr || textPr(false, false);
+		shaper.Script    = undefined !== nScript ? nScript : -1;
+		return shaper.GetFontSlot(nUnicode);
+	}
+
+	let failed = 0;
+	let total  = 0;
+
+	function check(sName, nActual, nExpected)
+	{
+		++total;
+		let isOk = (nActual === nExpected);
+		if (!isOk)
+			++failed;
+
+		let sText = (isOk ? "PASS" : "FAIL") + "  " + sName
+			+ "  ->  " + SLOT_NAME[nActual]
+			+ (isOk ? "" : "  (expected " + SLOT_NAME[nExpected] + ")");
+
+		if (root.document)
+		{
+			let div = root.document.createElement("div");
+			div.textContent = sText;
+			div.style.color = isOk ? "#207520" : "#c00000";
+			root.document.body.appendChild(div);
+		}
+		console.log(sText);
+	}
+
+	/**
+	 * Asserts the slot is the one the unpatched lookup would give. Used for
+	 * everything that must keep its current behaviour, so the expected value
+	 * cannot drift out of date.
+	 */
+	function checkSame(sName, nUnicode, isDrawing, oTextPr, nScript)
+	{
+		oTextPr = oTextPr || textPr(false, false);
+		check(sName, slotOf(nUnicode, isDrawing, oTextPr, nScript),
+			AscWord.GetFontSlotByTextPr(nUnicode, oTextPr));
+	}
+
+	const DRAWING  = true;
+	const DOCUMENT = false;
+
+	// ---- DrawingML: the scripts PowerPoint draws with <a:cs> ----------------
+	check("DrawingML Hebrew alef U+05D0", slotOf(0x05D0, DRAWING), AscWord.fontslot_CS);
+	check("DrawingML Arabic alef U+0627", slotOf(0x0627, DRAWING), AscWord.fontslot_CS);
+	check("DrawingML Syriac alaph U+0710", slotOf(0x0710, DRAWING), AscWord.fontslot_CS);
+	check("DrawingML Syriac Supplement U+0860", slotOf(0x0860, DRAWING), AscWord.fontslot_CS);
+
+	// ---- DrawingML: everything else keeps the slot it had -------------------
+	check("DrawingML Latin A U+0041", slotOf(0x0041, DRAWING), AscWord.fontslot_ASCII);
+	check("DrawingML Hiragana U+3042", slotOf(0x3042, DRAWING), AscWord.fontslot_EastAsia);
+	// Greek and Cyrillic land in fontslot_HAnsi, which the drawer resolves to
+	// _rfonts.HAnsi - filled from <a:latin> just as Ascii is. Asserted against
+	// the unpatched lookup rather than a hard coded slot.
+	// Thaana is right-to-left and sits in the same lookup range as Hebrew and
+	// Arabic, but PowerPoint keeps it on <a:latin>. This is what stops the
+	// condition from being a plain right-to-left test.
+	checkSame("DrawingML Thaana U+0780 unchanged", 0x0780, DRAWING);
+	checkSame("DrawingML Greek U+03B1 unchanged", 0x03B1, DRAWING);
+	checkSame("DrawingML Cyrillic U+0410 unchanged", 0x0410, DRAWING);
+
+	// ---- WordprocessingML must not change ----------------------------------
+	// Word draws a flagless Hebrew run with the ascii/hAnsi font, not the cs one.
+	check("Document Hebrew, no flags", slotOf(0x05D0, DOCUMENT), AscWord.fontslot_ASCII);
+	check("Document Arabic, no flags", slotOf(0x0627, DOCUMENT), AscWord.fontslot_ASCII);
+	checkSame("Document Thaana unchanged", 0x0780, DOCUMENT);
+	checkSame("Document Japanese unchanged", 0x3042, DOCUMENT);
+	check("Document Hebrew, <w:cs/>", slotOf(0x05D0, DOCUMENT, textPr(true, false)), AscWord.fontslot_CS);
+	check("Document Hebrew, <w:rtl/>", slotOf(0x05D0, DOCUMENT, textPr(false, true)), AscWord.fontslot_CS);
+
+	// ---- An explicit flag still wins in DrawingML too -----------------------
+	// The flags are never set there today, but if a path ever sets them it takes
+	// precedence over the character.
+	check("DrawingML Latin, CS set", slotOf(0x0041, DRAWING, textPr(true, false)), AscWord.fontslot_CS);
+	check("DrawingML Latin, RTL set", slotOf(0x0041, DRAWING, textPr(false, true)), AscWord.fontslot_CS);
+
+	// ---- Marks and joiners follow the base letter --------------------------
+	// A font change flushes the shaping buffer, so a mark that lands in another
+	// slot than its base is shaped apart from it and the word comes out broken.
+	//
+	// U+060C..U+074A is folded into Arabic by GetTextScript, so these need no
+	// help from the segment - Script is left unset to show that.
+	check("DrawingML fatha U+064E", slotOf(0x064E, DRAWING, null, -1), AscWord.fontslot_CS);
+	check("DrawingML shadda U+0651", slotOf(0x0651, DRAWING, null, -1), AscWord.fontslot_CS);
+	check("DrawingML sukun U+0652", slotOf(0x0652, DRAWING, null, -1), AscWord.fontslot_CS);
+	check("DrawingML tatweel U+0640", slotOf(0x0640, DRAWING, null, -1), AscWord.fontslot_CS);
+	check("DrawingML Arabic comma U+060C", slotOf(0x060C, DRAWING, null, -1), AscWord.fontslot_CS);
+
+	// Outside that range a mark is Inherited and carries no script of its own,
+	// so it continues the segment. ZWJ inside an Arabic word is the real case.
+	check("DrawingML ZWJ in Arabic segment",
+		slotOf(0x200D, DRAWING, null, SCRIPT.HB_SCRIPT_ARABIC), AscWord.fontslot_CS);
+	check("DrawingML ZWNJ in Arabic segment",
+		slotOf(0x200C, DRAWING, null, SCRIPT.HB_SCRIPT_ARABIC), AscWord.fontslot_CS);
+	check("DrawingML ZWJ in Hebrew segment",
+		slotOf(0x200D, DRAWING, null, SCRIPT.HB_SCRIPT_HEBREW), AscWord.fontslot_CS);
+	checkSame("DrawingML ZWJ in Latin segment unchanged",
+		0x200D, DRAWING, null, SCRIPT.HB_SCRIPT_LATIN);
+
+	// Common is deliberately not carried forward: a space after Hebrew keeps the
+	// slot it has without this change, and it already ends a shaping segment.
+	checkSame("DrawingML space after Hebrew segment unchanged",
+		0x0020, DRAWING, null, SCRIPT.HB_SCRIPT_HEBREW);
+	checkSame("DrawingML digit after Hebrew segment unchanged",
+		0x0031, DRAWING, null, SCRIPT.HB_SCRIPT_HEBREW);
+
+	let sResult = failed
+		? (failed + " of " + total + " checks FAILED")
+		: ("all " + total + " checks passed");
+
+	if (root.document)
+	{
+		let h = root.document.createElement("h3");
+		h.textContent = sResult;
+		h.style.color = failed ? "#c00000" : "#207520";
+		root.document.body.appendChild(h);
+	}
+	console.log(sResult);
+
+	if (failed && typeof process === "object" && process.exit)
+		process.exit(1);
+
+})(typeof window !== "undefined" ? window : globalThis);

--- a/word/Editor/Paragraph/test/fontslot.js
+++ b/word/Editor/Paragraph/test/fontslot.js
@@ -154,6 +154,8 @@
 	check("DrawingML Arabic alef U+0627", slotOf(0x0627, DRAWING), AscWord.fontslot_CS);
 	check("DrawingML Syriac alaph U+0710", slotOf(0x0710, DRAWING), AscWord.fontslot_CS);
 	check("DrawingML Syriac Supplement U+0860", slotOf(0x0860, DRAWING), AscWord.fontslot_CS);
+	check("DrawingML Thaana U+0780", slotOf(0x0780, DRAWING), AscWord.fontslot_CS);
+	check("DrawingML Thaana U+07A6", slotOf(0x07A6, DRAWING), AscWord.fontslot_CS);
 
 	// ---- DrawingML: everything else keeps the slot it had -------------------
 	check("DrawingML Latin A U+0041", slotOf(0x0041, DRAWING), AscWord.fontslot_ASCII);
@@ -161,10 +163,6 @@
 	// Greek and Cyrillic land in fontslot_HAnsi, which the drawer resolves to
 	// _rfonts.HAnsi - filled from <a:latin> just as Ascii is. Asserted against
 	// the unpatched lookup rather than a hard coded slot.
-	// Thaana is right-to-left and sits in the same lookup range as Hebrew and
-	// Arabic, but PowerPoint keeps it on <a:latin>. This is what stops the
-	// condition from being a plain right-to-left test.
-	checkSame("DrawingML Thaana U+0780 unchanged", 0x0780, DRAWING);
 	checkSame("DrawingML Greek U+03B1 unchanged", 0x03B1, DRAWING);
 	checkSame("DrawingML Cyrillic U+0410 unchanged", 0x0410, DRAWING);
 
@@ -172,6 +170,8 @@
 	// Word draws a flagless Hebrew run with the ascii/hAnsi font, not the cs one.
 	check("Document Hebrew, no flags", slotOf(0x05D0, DOCUMENT), AscWord.fontslot_ASCII);
 	check("Document Arabic, no flags", slotOf(0x0627, DOCUMENT), AscWord.fontslot_ASCII);
+	// Thaana is one of the four scripts that move in DrawingML, so this is the
+	// case that shows the split is by content origin and not by script alone.
 	checkSame("Document Thaana unchanged", 0x0780, DOCUMENT);
 	checkSame("Document Japanese unchanged", 0x3042, DOCUMENT);
 	check("Document Hebrew, <w:cs/>", slotOf(0x05D0, DOCUMENT, textPr(true, false)), AscWord.fontslot_CS);


### PR DESCRIPTION

Fixes ONLYOFFICE/DocumentServer#3539.

A theme's `<a:cs>` is never used when text is laid out from DrawingML. Hebrew, Arabic,
Syriac and Thaana in a presentation are drawn with `<a:latin>` instead, so a theme that
names a proper complex script face has no effect. PowerPoint uses `<a:cs>` for the same
file.

## Why the slot is unreachable

`GetFontSlot` in `word/Editor/Paragraph/Run/FontClassification.js` ends with:

```js
if (isCS || isRTL)
    return fontslot_CS;

return nSlot ? nSlot : fontslot_ASCII;
```

`fontslot_CS` is returned only when one of those two flags is set, and
`GetFontSlotByTextPr` takes them from `oTextPr.CS` / `oTextPr.RTL`. Those come from
`<w:cs/>` and `<w:rtl/>`.

**DrawingML has no counterpart.** `<a:rPr>` carries no complex-script or right-to-left
flag, so for text that came from a `<a:txBody>` neither flag is ever set and the slot
cannot be reached at all. The lookup table agrees with that reading: Hebrew, Arabic,
Syriac and Thaana share `FillRange(0x0590, 0x07BF, [fontslot_ASCII, fontslot_ASCII,
fontslot_ASCII])`, and the Arabic presentation forms are `fontslot_ASCII` as well. That is
correct for WordprocessingML, where the flags carry the decision; it leaves DrawingML with
no way to express it.

Everything downstream of the slot already works. `CTextDrawer.SetFontSlot` in
`common/Drawings/TextDrawer.js` resolves `fontslot_CS` to `_rfonts.CS.Name`, and the
shaper already picks a slot per character - a run mixing Latin and Japanese is drawn with
`<a:latin>` and `<a:ea>` in the right places today. Only this one slot is unreachable.

## The change

`word/Editor/Paragraph/TextShaper.js` - `CParagraphTextShaper.prototype.GetFontSlot`

```js
if (this.Paragraph
    && false === this.Paragraph.bFromDocument
    && !oTextPr.CS
    && !oTextPr.RTL)
{
    let nScript = this.GetTextScript(nUnicode);

    if (AscFonts.HB_SCRIPT.HB_SCRIPT_INHERITED === nScript)
        nScript = this.Script;

    if (AscFonts.HB_SCRIPT.HB_SCRIPT_HEBREW === nScript
        || AscFonts.HB_SCRIPT.HB_SCRIPT_ARABIC === nScript
        || AscFonts.HB_SCRIPT.HB_SCRIPT_SYRIAC === nScript
        || AscFonts.HB_SCRIPT.HB_SCRIPT_THAANA === nScript)
        return AscWord.fontslot_CS;
}
```

`GetTextScript` is this class's own method and the `HB_SCRIPT` constants are already used a
few lines below in this same file (`GetLigaturesType` tests for `HB_SCRIPT_ARABIC`); no new
predicate and no new table. `GetFontSlot` and the lookup table are untouched, so
WordprocessingML keeps its flag-driven behaviour exactly. An explicit `CS` or `RTL` still
wins, so a future DrawingML path that does carry the flags would take precedence over the
character.

**The slot is classified the same way the segments are.** `private_CheckNewSegment` already
calls `GetTextScript` to decide where a shaping segment ends, so reusing it here keeps the
slot from changing in the middle of one. It also means the existing `U+060C..U+074A ->
Arabic` correction in `GetTextScript` applies: Arabic vowel marks and tatweel follow their
base letter, and most Syriac reaches this code as Arabic - the `HB_SCRIPT_SYRIAC` branch
covers the Syriac Supplement block.

**Marks have to follow the segment, not their own code point.** Combining marks outside
that range are `Inherited`, so a per-code-point test would put a letter in the CS slot and
its marks in the ASCII slot. A font change flushes the shaping buffer (`textshaper.js`), so
the marks would be shaped apart from the letter they belong to; `اَلْعَرَبِيَّة` came out
visibly broken while I was classifying per code point. The flag-driven path never had this
problem, because `isCS || isRTL` applies to every code point in the run regardless of
script. Carrying `this.Script` forward for `Inherited` restores that, and mirrors what the
shaper already does with `this.Script` itself. `Common` is deliberately not carried
forward: spaces, digits and punctuation that `GetTextScript` leaves as `Common` keep the
slot they have on a stock build, and they already end a shaping segment there. Arabic
punctuation is not in that group - `U+060C` and the rest of `U+060C..U+074A` have already
been made Arabic by the correction above, which is why they follow the letters.

**The script list is measured, not derived.** Hebrew, Arabic, Syriac and Thaana are the
four I measured against PowerPoint, and all four are drawn with `<a:cs>` there. I am
deliberately not turning that into a rule about right-to-left or complex scripts in
general: the evidence covers those four and nothing else, so adding a fifth should mean
measuring it first. N'Ko and Adlam, for instance, are right-to-left and are not included.

The corresponding table in WordprocessingML is documented - [MS-OI29500] §17.3.2.26 lists
Hebrew, Arabic, Syriac, Arabic Supplement and Thaana as **ascii**, and says the `cs` font
is used when the `cs` or `rtl` element is present "regardless of the Unicode character
values". That is the rule this change deliberately leaves alone, and it is why the lookup
table is not touched. It is not a specification for the DrawingML side, which has no such
flags; I mention it only because it explains why the WordprocessingML behaviour is correct
as it stands. If you would rather see the DrawingML side expressed as those same block
ranges instead of a script list, say so - but I would not want to write that down as a rule
without having measured it.

`Paragraph.bFromDocument` is the existing distinction that picks out the
`CDrawingDocContent` this change is meant for. `CShape` keeps its text in two places and
fills them by format: `txBody` is a `CDrawingDocContent`, which passes `bPresentation =
true` unconditionally, while a Word text box goes to `textBoxContent`, a plain
`CDocumentContent` created without that argument. The readers split the same way -
`setTxBody(this.ReadTextBody(shape))` against
`setTextBoxContent(new CDocumentContent(..., false, false))` in `common/Shapes/Serialize.js`.

I am relying on that correspondence rather than on a flag that names the source format
directly, so it is worth a look. The negative control is the strongest evidence I have for
it: Hebrew inside a `<w:txbxContent>` text box renders identically before and after, in the
same document where a chart title changes.

## Why this is not applied to WordprocessingML

Because Word does not do it, and the current code already matches Word.

I measured this rather than assuming it. In a `.docx` whose runs carry an explicit `w:cs`
face and no flags, Word draws Hebrew with the **ascii/hAnsi** font, not the `w:cs` one; it
switches to `w:cs` only when `<w:cs/>` or `<w:rtl/>` is present. Setting ascii/hAnsi to a
face with a visibly different Hebrew design moves the Hebrew with it. All five controls
agree, and ONLYOFFICE renders all five the same way Word does today.

Making the character drive the slot in the shared path would therefore be a regression for
`.docx`. Restricting it to DrawingML is not "Word should do this too" - it is that
`<a:rPr>` has nothing to decide with.

The same DrawingML path is also used by chart rich text in `.docx` and by shape text in
`.xlsx`. I verified both: a Hebrew chart title and a Hebrew shape label now resolve through
`<a:cs>`, matching Word and Excel respectively. This is an intentional consequence of
limiting the change by content origin rather than by editor type. A text box goes to
`textBoxContent` and is not affected.

## Measurements

The runs under test carry no real font names; each references `+mn-lt` / `+mn-ea` /
`+mn-cs` only, so the theme decides everything. To avoid judging typefaces by eye, each
result comes from a **pair of files whose probe text is identical and whose theme differs
in one slot**: if changing `<a:cs>` changes the rendering, `<a:cs>` is being used. (The
probes also carry a footer naming the faces they need, so that a missing font is not
mistaken for the fix not working. It is a separate shape with no theme reference and is
not part of what is measured.)

| Script | PowerPoint | ONLYOFFICE 9.4.0 | after this change |
| --- | --- | --- | --- |
| Latin | latin | latin | unchanged |
| Greek | latin | latin | unchanged |
| Cyrillic | latin | latin | unchanged |
| Japanese | ea | ea | unchanged |
| **Hebrew** | **cs** | latin | **cs** |
| **Arabic** | **cs** | latin | **cs** |
| **Syriac** | **cs** | latin | **cs** |
| **Thaana** | **cs** | latin | **cs** |

Greek and Cyrillic are there because they are non-Latin but stay on `<a:latin>` in
PowerPoint: the change is not "non-Latin goes to cs".

**Thaana was measured twice.** The first reading said `<a:latin>` and was wrong: it rested
on telling two similar faces apart by eye, and the re-run was then masked by PowerPoint's
startup font cache after the test faces were installed. A positive control - a file whose
*Latin* face must visibly change - did not change either, which is what exposed the stale
cache. After restarting PowerPoint, Thaana follows `<a:cs>` like the other three. The
condition names scripts rather than testing a property because the property is what I
cannot demonstrate, not because Thaana is an exception.

For the Syriac and Thaana readings I used two faces of the same family that differ only in
weight (Thin against Black), so the two outcomes are a hairline or an ultra-bold stroke -
no typeface judgement involved. Each was also confirmed with the two faces swapped between
`<a:latin>` and `<a:cs>`.

Swapping only `<a:cs>` produced no change at all on a stock build - which is the direct
evidence that the slot was unreachable - and produces a changed glyph shape with this
applied, matching PowerPoint.

## Deliberately not changed

**`<a:font script="..."/>`.** These are still not consulted anywhere when resolving a font,
with or without this change; the model does not even keep them without
ONLYOFFICE/sdkjs#4883. That is the first screenshot in DocumentServer#1415 and a separate
piece of work. This PR does not depend on #4883 and can land in either order - I verified
the fix on a clean `release/v9.4.0` with only this patch applied.

**Comb form fields.** `CRunElementBase.SetGapBackground` computes `RGapFontSlot` through
`GetFontSlotByTextPr` and is left alone. Its only caller is the comb text-form code in
`Run.js`, and it only affects the placeholder background drawn in the empty cells of a comb
field - a WordprocessingML forms feature, outside the path this change touches.

**Caret geometry.** Caret x is accumulated from `element.GetWidthVisible()`, the same widths
the layout measures and the drawer uses, so it follows this change automatically; a
selection across mixed Hebrew and Latin lines up with the glyphs. Caret *height* is a
separate matter: `ParagraphPositionCalculator.getTargetXY` measures it with
`fontslot_ASCII` whatever slot the run resolved to. That is existing behaviour - a
`<w:cs/>` run in a document already reaches it - and this change makes more text do so. I
have left it alone.

Font size is not affected: the DrawingML reader assigns `sz` to both `FontSize` and
`FontSizeCS`, so switching to the CS slot changes the typeface and nothing else.

**Cell text in a spreadsheet.** `FragmentShaper.GetFontSlot` in `cell/view/StringRender.js`
returns `fontslot_ASCII` unconditionally and is untouched. Excel does not classify by script
inside a cell either: a cell's scheme font resolves to a single face for the whole string,
and where a cell does show several fonts they come from explicit rich text runs, which name
their own font and never reach slot selection. So cell text is a separate question from
this one. Shape text on a sheet is DrawingML and is covered, as above.

## Testing

- `build/build.py --product cell|word|slide --desktop` all succeed.
- Presentations: Hebrew, Arabic, Syriac and Thaana reach `<a:cs>` and match PowerPoint.
  Greek, Cyrillic, Japanese and per-character switching within a run are unchanged.
- Documents: five explicit-font controls in a `.docx` body render exactly as before, and so
  does Hebrew inside a `<w:txbxContent>` text box - the case that would break if
  `bFromDocument` did not separate the two. A chart title in the same document does change,
  from `<a:latin>` to `<a:cs>`, which is what Word draws for it.
- Spreadsheets: a Hebrew shape label goes from `<a:latin>` to `<a:cs>`, which is what Excel
  draws for the same file. Cell text itself is unchanged.
- A build with the same tree but without this patch still shows the defect, so the change
  is attributable to it.
- **`test.pptx` attached to the issue**: its Hebrew renders in Calibri on a stock build and
  in Arial with this applied, matching what PowerPoint draws for the same file. That build
  had only this patch on top of `release/v9.4.0`.
- Thaana reaches `<a:cs>`, which is what PowerPoint draws. Measured with two faces of the
  same family differing only in weight, alongside a positive control on the `<a:latin>`
  face; see the note above about the first, invalid reading.
- Vowelled Arabic (`اَلْعَرَبِيَّة`), shadda (`شَدَّة`) and tatweel (`عـــربية`) render as they do
  on a stock build and in PowerPoint, and the whole word including the marks moves when the
  `<a:cs>` font is swapped. An earlier version of this patch classified per code point and
  broke them, so this case is worth keeping in mind for any later change here.
- Desktop Editors 9.4.0, macOS 26, Apple Silicon. Not run against Document Server or the
  Docker image. The repository workflow is not configured to run for PRs targeting
  `master`; its configured test path is currently absent from the target branches, so no
  upstream regression suite could be run for this change.

One detail worth recording, since `lang` is the obvious alternative signal: every run in my
own probes carries `lang="en-US"`, including the Hebrew, and PowerPoint still resolves it
through `<a:cs>`. The reporter's file has `lang="he-IL"` and renders the same way. So
PowerPoint is deciding from the characters, not from `lang` - which is what this patch does.

Line numbers above are from `release/v9.4.0`; the patch applies cleanly to `master`, where
`GetFontSlot` is identical.

## Reproducing

The probe generators are small and self-contained (Python 3 standard library only). They
build the `.pptx` / `.docx` pairs described above and check first that every face used is
installed and actually covers the script being tested - an uncovered face falls back and is
then indistinguishable from a different slot.

Verified on Debian:

```bash
apt-get install -y python3 fonts-noto-core fonts-noto-cjk fonts-noto-extra
python3 check_coverage.py --set linux        # every face covers its script
python3 make_pptx_probe.py --set linux       # build the probes
python3 verify_probe_fonts.py linux          # every name in the output resolves
```

`fonts-noto-extra` is only needed for the Syriac pair: `fonts-noto-core` ships one Syriac
face, and one face cannot tell the two slots apart because both fall back to it.

I am happy to attach the generators, or to reduce this to a couple of static files if you
would rather have a plain reproducer.
