### PR TITLE
[de] Fix bug #73801: left column goes invisible after widow-control restart

### DIFF
--- a/word/Editor/document/document-page-section.js
+++ b/word/Editor/document/document-page-section.js
@@ -78,16 +78,23 @@
 		var oFrame  = oSectPr.GetContentFrame(nPageAbs);
 		var nX      = oFrame.Left;
 		var nXLimit = oFrame.Right;
-		
+
 		for (var nCurColumn = 0, nColumnsCount = oSectPr.GetColumnCount(); nCurColumn < nColumnsCount; ++nCurColumn)
 		{
-			this.Columns[nCurColumn] = new AscWord.DocumentPageColumn();
-			
+			// Preserve already-computed layout (Pos/EndPos/Empty/Bounds) for columns that
+			// already exist here — Init() can be called to restart recalculation of a later
+			// column without invalidating an earlier column in the same section that was
+			// already correctly laid out (e.g. widow-control restarts). Only build a fresh
+			// column object when one doesn't exist yet at this index.
+			if (!this.Columns[nCurColumn])
+				this.Columns[nCurColumn] = new AscWord.DocumentPageColumn();
+
 			this.Columns[nCurColumn].X      = nX;
 			this.Columns[nCurColumn].XLimit = nColumnsCount - 1 === nCurColumn ? nXLimit : nX + oSectPr.GetColumnWidth(nCurColumn);
-			
+
 			nX += oSectPr.GetColumnWidth(nCurColumn) + oSectPr.GetColumnSpace(nCurColumn);
 		}
+		this.Columns.length = nColumnsCount;
 		this.ColumnsSep = oSectPr.GetColumnSep();
 		
 		this.Y       = oFrame.Top;


### PR DESCRIPTION
## Summary

Fixes https://github.com/ONLYOFFICE/DocumentServer/issues/3642 — in a multi-column section, a column that was already correctly laid out can go invisible (content still present in the document model, just not rendered/reachable) after a widow/orphan-control restart moves recalculation back to an earlier column on the same page.

## Root cause

`DocumentPageSection.prototype.Init()` unconditionally rebuilds `this.Columns` from scratch:

```js
for (var nCurColumn = 0, nColumnsCount = oSectPr.GetColumnCount(); nCurColumn < nColumnsCount; ++nCurColumn)
{
    this.Columns[nCurColumn] = new AscWord.DocumentPageColumn();
    ...
}
```

`Init()` is called any time recalculation needs to restart within the same page/section — e.g. when widow control determines a line at the top of a later column needs to move, and recalculation restarts from an earlier column in the same section (`Document.js`, `recalcresult_PrevPage | recalcresultflags_Column` handling in `Recalculate_PageColumn`). In that case the earlier column may already have valid, fully-computed `Pos`/`EndPos`/`Empty`/`Bounds`, but `Init()` discards it and replaces it with a freshly-constructed column (`Pos: 0, EndPos: -1, Empty: true`). If the subsequent forward recalculation pass doesn't get back around to fully re-laying out that column before something else interrupts it, the wiped default state is what ends up rendered — an empty, uninteractive column, even though the underlying content is untouched.

Confirmed via runtime instrumentation against the minimal repro attached to #3642: the left column's `Pos`/`EndPos` snapshot immediately before/after `Init()` matches exactly this pattern (`Pos=9, EndPos=12` → `Pos=0, EndPos=-1, Empty=true`).

## Fix

Update column objects in place (preserving `Pos`/`EndPos`/`Empty`/`Bounds`) when one already exists at a given index; only construct a fresh `DocumentPageColumn` when one doesn't exist yet at that index. All of `Init()`'s other side effects — geometry (`X`/`XLimit`), `ColumnsSep`, vertical bounds (`Y`/`YLimit`/`YLimit2`), and bottom-limit iteration reset — are unchanged, since those turned out to matter: an earlier attempt that skipped the whole `Init()` call for same-page/same-section restarts caused an infinite recalculation loop, presumably because something depends on the iteration-state reset to converge. This version only changes whether existing column objects get replaced vs. updated.

## Testing

Built and manually verified against the `columns.disappear.docx` repro from #3642 in a local desktop build:
- Fresh document open: left column on the affected page now renders correctly (previously invisible on open, no editing required to trigger it).
- Live-edit trigger (typing until widow control fires): column stays visible, no regression in the fix/reflow behavior itself.
- No hang/infinite loop, no other regressions observed in general document editing/pagination during testing.