### PR TITLE
fix: Use correct quotation marks for Danish

### DIFF
--- a/word/Editor/Paragraph/Run/RunAutoCorrect.js
+++ b/word/Editor/Paragraph/Run/RunAutoCorrect.js
@@ -475,7 +475,6 @@
 					this.Run.AddToContent(this.Pos, new AscWord.CRunText(isOpenQuote ? 0x201E : 0x201D));
 					break;
 				}
-				case 1030:
 				case 1035:
 				case 1053:
 				{
@@ -489,6 +488,7 @@
 					this.Run.AddToContent(this.Pos, new AscWord.CRunText(isOpenQuote ? 0x00AB : 0x00BB));
 					break;
 				}
+				case 1030:
 				case 1060:
 				{
 					// »text«


### PR DESCRIPTION
Danish typographic tradition uses two standards for quotation marks.

1. Guillemets pointing to the quote: »Example«.
2. Down-9s and Up-6s: „Example“.

Onlyoffice currently has dual Up-9s set for Danish: ”Example”.

This commit changes Danish typographer's quotes or smart quotes to guillemets, which is the most widespread in professional Danish typography.

I have intentionally left the single quotes as they are, since using the correct ones tends to cause issues with apostrophes.