### PR TITLE
[se] Limit structured #This Row recursion checks to the formula row

### DIFF
--- a/cell/model/FormulaObjects/parserFormula.js
+++ b/cell/model/FormulaObjects/parserFormula.js
@@ -8426,8 +8426,11 @@ function parserFormula( formula, parent, _ws ) {
 					return oRange.containCell2(parserFormula.getParent());
 				}
 			} else if (nOperandType === cElementType.table) {
-				let oRefElem = found_operand.toRef();
-				oRange = oRefElem.getRange();
+				const oParent = parserFormula.getParent();
+				const oParentRange = oParent.onFormulaEvent &&
+					oParent.onFormulaEvent(AscCommon.c_oNotifyParentType.GetRangeCell);
+				let oRefElem = found_operand.toRef(oParentRange);
+				oRange = oRefElem && oRefElem.getRange && oRefElem.getRange();
 			} else {
 				oRange = found_operand && found_operand.getRange && found_operand.getRange();
 			}


### PR DESCRIPTION
## Summary

- resolve dynamic structured table operands against the formula parent cell during recursion detection
- avoid expanding `#This Row` / `@column` references to the entire table data column
- preserve direct and indirect circular-reference detection

## Problem

`isRecursiveFormula` converted structured table operands with `toRef()` but without the parent cell range. For dynamic `#This Row` references, `cStrucTable.toRef` documents that a missing bounding box falls back to the full table data area.

When pasting 1,500 formulas containing `table1[@description]` into a table with 8,000 data rows, recursion detection therefore visited the 8,000-row column for every formula: 12,000,000 `Cell.checkRecursiveFormula` calls.

The change passes the current formula cell as the bounding range, so the same operand resolves to its intended one-row reference before recursion traversal.

## Benchmark

Fixture: [performance-test.xlsx](https://github.com/ONLYOFFICE/CommunityServer/files/14823375/performance-test.xlsx), containing 80,000 formulas in table `A1:L8001`.

Scenario: copy `C2:C1501` and paste to `L2:L1501` through the internal spreadsheet clipboard path.

| | Baseline `develop` | With this change |
|---|---:|---:|
| Median of 5 clean runs | 1,359.8 ms | 304.6 ms |
| Min–max | 1,314.9–1,416.3 ms | 266.4–318.0 ms |
| Recursive cell checks | 12,000,000 | 1,500 |

This is a 4.46× speedup and a 77.6% median runtime reduction in the reproduced paste path. A separate full-column stress run pasted all 8,000 formulas in 1,120.1 ms; the first and last formulas matched their sources. Absolute timings are local Windows/Chromium measurements; baseline and fixed runs used the same browser session, fixture, and harness.

## Correctness checks

- pasted formula text matches the source formula
- non-circular `table1[@description]` reference is not marked circular
- direct current-row self-reference remains marked circular
- indirect current-row cycle `B2 -> C2 -> B2` remains marked circular
- a current-row table reference outside the table data rows returns `#VALUE!` without a JavaScript exception
- sabotage check: reverting the source change makes the regression assertion fail again with 12,000,000 recursive checks

## Builds

```text
python build/build.py --develop --product cell
python build/build.py --product cell
```

Both builds completed successfully on Windows.

The last public suites from before the test-tree removal were restored locally and run against this branch:

- `FormulaTests`: 47 tests, 2,804/2,804 assertions passed
- `copy-paste-tests`: 10 tests, 110/110 assertions passed

## Scope

This hot path was identified while profiling the public workbook associated with ONLYOFFICE/DocumentServer#2683. The remaining public report in that issue concerns slow `Ctrl+C` on a separate private workbook. This pull request addresses the independently reproduced structured-reference paste path and does not claim to close #2683.

The public `sdkjs` repository no longer contains the spreadsheet test suite on `develop`; the local regression harness and benchmark results can be provided for integration into the maintainers' `sdkjs-tests` suite.
