### PR TITLE
[se] Skip numeric text layout without column autofit

### DIFF
--- a/cell/view/WorksheetView.js
+++ b/cell/view/WorksheetView.js
@@ -9857,9 +9857,9 @@ function isAllowPasteLink(pastedWb) {
 		var th;
 		var cellType = cell.getType();
 		var wrap = align.getWrap() || align.hor === AscCommon.align_Distributed;
-		// Autofit is done for any type (except string)
 		var isNumberFormat = !cell.isEmptyTextString() && (null === cellType || CellValueType.String !== cellType);
-		if (angle || isNumberFormat || wrap) {
+		// Wrapped or rotated text needs full layout; numbers also need it while column autofit is enabled.
+		if (angle || wrap || (isNumberFormat && c_oAscCanChangeColWidth.none !== this.canChangeColWidth)) {
 			this._addCellTextToCache(cell.nCol, cell.nRow);
 			th = this.updateRowHeightValuePx || AscCommonExcel.convertPtToPx(this._getRowHeightReal(cell.nRow));
 		} else {


### PR DESCRIPTION
## Problem

Sorting a large numeric range queues every affected row for height recalculation. `WorksheetView._updateRowHeight2()` then treats every non-string value as requiring full text layout and calls `_addCellTextToCache()` for every numeric cell.

For a 100,000 × 10 numeric worksheet this requests up to 1,000,000 `CacheElementText` / `StringRender` states during the synchronous post-sort view recalculation. This bypasses the otherwise lazy, viewport-oriented text cache and can cause high memory use or a browser crash.

Related to ONLYOFFICE/DocumentServer#2221 (internal issue 48108).

## Approach

Use full text layout for row-height calculation only when layout is height-sensitive or required for column autofit:

- wrapped/distributed text;
- rotated text;
- numeric cells while numeric/all-column autofit is enabled.

Sorting keeps `canChangeColWidth` at `none`, so unwrapped, unrotated values use the existing fragment font-metrics loop immediately below the branch. That loop already accounts for each fragment's font and vertical alignment. Numeric edit paths that allow column autofit retain the previous full-layout behavior. The sort operation, cache invalidation, row scan, merge handling, custom row heights, and model/history logic are unchanged.

## Reproduction and performance evidence

A local headless harness opens a deterministic 100,000-row × 10-column `Editor.bin`, sorts all rows, runs `_updateRange()` and `_recalculate()`, and verifies all coupled row values plus style sentinels.

Five runs per variant:

| Variant | Full text-cache requests during sort | Numeric-autofit sentinel |
|---|---:|---:|
| Old numeric condition (sabotage) | 1,000,000 in every run | retained |
| Proposed condition | 2 in every run | 1 full-layout call in every run |

The two remaining requests are intentional sentinels: one wrapped numeric cell and one 45° rotated numeric cell.

The harness suppresses the allocation body of `_addCellTextToCache()` in both variants to avoid intentionally materializing one million full text layouts. Therefore wall time is not used as the acceptance criterion; the deterministic 1,000,000 → 2 request count is the primary evidence.

Additional invariants:

- all 100,000 rows and 10 columns remained coupled after sort;
- wrap and 45° rotation remained attached to the correct cells;
- custom number format `$#,##0.00_);[Red]($#,##0.00)` was preserved;
- a 37 pt numeric cell calculated a 39 px row height through deterministic font metrics with zero full-layout calls.
- enabling numeric column autofit still selected the full-layout path in every run.

## Verification

- `SheetStructureTests`: 7,213 / 7,213 assertions
- `FormulaTests`: 2,804 / 2,804 assertions
- `autoFilterTests`: 705 / 705 assertions
- `CellSettingsTests`: 42 / 42 assertions
- `copy-paste-tests`: 110 / 110 assertions
- `node --check cell/view/WorksheetView.js`
- `git diff --check`
- development build: Word, Cell, Slide, Visio
- deploy build: Word, Cell, Slide, Visio

The local test harness is not part of the commit because this repository does not track the `tests/` directory.

## Scope and risk

The change is limited to `WorksheetView._updateRowHeight2()`. Wrapped or rotated cells and numeric column-autofit retain the previous full-layout path. Other unwrapped cells with non-default font size/style and vertical alignment continue through the existing per-fragment font-metrics calculation.
